### PR TITLE
Add the merges endpoint under GHRepos.

### DIFF
--- a/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
@@ -109,6 +109,15 @@ class GHRepos(accessToken: Option[String] = None)(implicit O: RepositoryOps[GitH
       context: Option[String] = None
   ): GHIO[GHResponse[Status]] =
     O.createStatus(owner, repo, sha, state, target_url, description, context, accessToken)
+
+  def merge(
+      owner: String,
+      repo: String,
+      base: String,
+      head: String,
+      commitMessage: Option[String] = None
+  ): GHIO[GHResponse[MergeResponse]] =
+    O.merge(owner, repo, base, head, commitMessage, accessToken)
 }
 
 class GHAuth(accessToken: Option[String] = None)(implicit O: AuthOps[GitHub4s]) {

--- a/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
@@ -116,7 +116,7 @@ class GHRepos(accessToken: Option[String] = None)(implicit O: RepositoryOps[GitH
       base: String,
       head: String,
       commitMessage: Option[String] = None
-  ): GHIO[GHResponse[MergeResponse]] =
+  ): GHIO[GHResponse[Option[MergeResponse]]] =
     O.merge(owner, repo, base, head, commitMessage, accessToken)
 }
 

--- a/github4s/shared/src/main/scala/github4s/api/Repos.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Repos.scala
@@ -266,6 +266,19 @@ class Repos[C, M[_]](
       headers,
       dropNullPrint(NewStatusRequest(state, target_url, description, context).asJson))
 
+  /**
+   * Merge code into a target branch.
+   *
+   * @param accessToken to identify the authenticated user
+   * @param headers optional user headers to include in the request
+   * @param owner of the repo
+   * @param repo name of the repo
+   * @param base the name of a branch to merge into
+   * @param head a branch or other ref to merge
+   * @param commitMessage Optional commit message to use for the merge
+   * @return A GHResponse with a response if Github provided one. Status == 204 with None as the return value means
+   *         the merge would do nothing and was not done.
+   */
   def merge(
       accessToken: Option[String] = None,
       headers: Map[String, String] = Map(),
@@ -273,8 +286,8 @@ class Repos[C, M[_]](
       repo: String,
       base: String,
       head: String,
-      commitMessage: Option[String] = None): M[GHResponse[MergeResponse]] =
-    httpClient.post[MergeResponse](
+      commitMessage: Option[String] = None): M[GHResponse[Option[MergeResponse]]] =
+    httpClient.post[Option[MergeResponse]](
       accessToken,
       s"repos/$owner/$repo/merges",
       headers,

--- a/github4s/shared/src/main/scala/github4s/api/Repos.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Repos.scala
@@ -265,4 +265,18 @@ class Repos[C, M[_]](
       s"repos/$owner/$repo/statuses/$sha",
       headers,
       dropNullPrint(NewStatusRequest(state, target_url, description, context).asJson))
+
+  def merge(
+      accessToken: Option[String] = None,
+      headers: Map[String, String] = Map(),
+      owner: String,
+      repo: String,
+      base: String,
+      head: String,
+      commitMessage: Option[String] = None): M[GHResponse[MergeResponse]] =
+    httpClient.post[MergeResponse](
+      accessToken,
+      s"repos/$owner/$repo/merges",
+      headers,
+      dropNullPrint(MergeRequest(base, head, commitMessage).asJson))
 }

--- a/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
@@ -96,6 +96,15 @@ final case class CreateStatus(
     accessToken: Option[String] = None
 ) extends RepositoryOp[GHResponse[Status]]
 
+final case class Merge(
+    owner: String,
+    repo: String,
+    base: String,
+    head: String,
+    commit_message: Option[String],
+    accessToken: Option[String] = None
+) extends RepositoryOp[GHResponse[MergeResponse]]
+
 /**
  * Exposes Repositories operations as a Free monadic algebra that may be combined with other Algebras via
  * Coproduct
@@ -191,6 +200,16 @@ class RepositoryOps[F[_]](implicit I: Inject[RepositoryOp, F]) {
   ): Free[F, GHResponse[Status]] =
     Free.inject[RepositoryOp, F](
       CreateStatus(owner, repo, sha, state, target_url, description, context, accessToken))
+
+  def merge(
+      owner: String,
+      repo: String,
+      base: String,
+      head: String,
+      commitMessage: Option[String] = None,
+      accessToken: Option[String] = None
+  ): Free[F, GHResponse[MergeResponse]] =
+    Free.inject[RepositoryOp, F](Merge(owner, repo, base, head, commitMessage, accessToken))
 }
 
 /**

--- a/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
@@ -103,7 +103,7 @@ final case class Merge(
     head: String,
     commit_message: Option[String],
     accessToken: Option[String] = None
-) extends RepositoryOp[GHResponse[MergeResponse]]
+) extends RepositoryOp[GHResponse[Option[MergeResponse]]]
 
 /**
  * Exposes Repositories operations as a Free monadic algebra that may be combined with other Algebras via
@@ -208,7 +208,7 @@ class RepositoryOps[F[_]](implicit I: Inject[RepositoryOp, F]) {
       head: String,
       commitMessage: Option[String] = None,
       accessToken: Option[String] = None
-  ): Free[F, GHResponse[MergeResponse]] =
+  ): Free[F, GHResponse[Option[MergeResponse]]] =
     Free.inject[RepositoryOp, F](Merge(owner, repo, base, head, commitMessage, accessToken))
 }
 

--- a/github4s/shared/src/main/scala/github4s/free/domain/Repository.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Repository.scala
@@ -103,6 +103,11 @@ case class Commit(
     author_url: Option[String]
 )
 
+case class CommitSummary(
+    sha: String,
+    url: String
+)
+
 case class NewReleaseRequest(
     tag_name: String,
     name: String,
@@ -150,6 +155,29 @@ case class CombinedStatus(
     statuses: List[Status],
     repository: StatusRepository
 )
+
+case class MergeRequest(
+    base: String,
+    head: String,
+    commit_message: Option[String]
+)
+
+case class MergeResponse(
+    sha: String,
+    commit: MergeCommit,
+    author: User,
+    committer: User,
+    parents: List[CommitSummary]
+)
+
+case class MergeCommit(
+    author: RefAuthor,
+    committer: RefAuthor,
+    message: String,
+    tree: CommitSummary,
+    comment_count: Int
+)
+
 object RepoUrlKeys {
 
   val forks_url         = "forks_url"

--- a/github4s/shared/src/main/scala/github4s/free/interpreters/Interpreters.scala
+++ b/github4s/shared/src/main/scala/github4s/free/interpreters/Interpreters.scala
@@ -114,6 +114,8 @@ class Interpreters[M[_], C](
             target_url,
             description,
             context)
+        case Merge(owner, repo, base, head, commit_message, accessToken) =>
+          repos.merge(accessToken, headers, owner, repo, base, head, commit_message)
       }
     }
   }

--- a/github4s/shared/src/test/scala/github4s/unit/GHReposSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHReposSpec.scala
@@ -164,4 +164,27 @@ class GHReposSpec extends BaseSpec {
         None,
         None)
   }
+
+  "GHRepos.merge" should "call to RepositoryOps with the right parameters" in {
+    val response: Free[GitHub4s, GHResponse[Option[MergeResponse]]] =
+      Free.pure(Right(GHResult(Some(validMergeResponse), okStatusCode, Map.empty)))
+    val repoOps = mock[RepositoryOpsTest]
+    (repoOps.merge _)
+      .expects(
+        validRepoOwner,
+        validRepoName,
+        validBase,
+        validCommitSha,
+        None,
+        sampleToken)
+      .returns(response)
+    val ghReposData = new GHRepos(sampleToken)(repoOps)
+    ghReposData
+      .merge(
+        validRepoOwner,
+        validRepoName,
+        validBase,
+        validCommitSha,
+        None)
+  }
 }

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -368,4 +368,12 @@ trait TestData extends DummyGithubUrls {
     html_url = "",
     pull_request_url = ""
   )
+
+  val validMergeResponse = MergeResponse(
+    validCommitSha,
+    MergeCommit(refCommitAuthor, refCommitAuthor, validCommitMsg, CommitSummary(validCommitSha, ""), 0),
+    user,
+    user,
+    List()
+  )
 }


### PR DESCRIPTION
Another WIP PR. Works for the known-good use case. [Documentation](https://developer.github.com/v3/repos/merging/#perform-a-merge)

Known issues:

* [ ] A 204 response which means that the merge would be a NOP will generate a `Left(github4s.GithubResponses$JsonParsingException: exhausted input)` instead of a useful error.