### PR TITLE
Require an http4s client to provide more flexibility

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -139,9 +139,10 @@ we'll be writing our tests in [GHReposSpec][repos-integ-spec]:
 
 ```scala
 "Repos >> ListStatus" should "return a non empty list when a valid ref is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listStatuses(validRepoOwner, validRepoName, validCommitSha, headers = headerUserAgent)
-      .unsafeRunSync()
+    val response = client.use { client =>
+      Github[IO](client, accessToken).repos
+        .listStatuses(validRepoOwner, validRepoName, validCommitSha, headers = headerUserAgent)
+    }.unsafeRunSync()
 
     testIsRight[List[Status]](response, { r =>
       r.nonEmpty shouldBe true
@@ -150,9 +151,11 @@ we'll be writing our tests in [GHReposSpec][repos-integ-spec]:
   }
 
   it should "return an error when an invalid ref is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listStatuses(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
-      .unsafeRunSync()
+    val response = client.use { client =>
+      Github[IO](client, accessToken).repos
+        .listStatuses(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
+    }.unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
@@ -208,9 +211,7 @@ You can also list statuses through `listStatuses`; it take as arguments:
 To list the statuses for a specific ref:
 
 {triple backtick}scala mdoc:silent
-val listStatuses =
-  Github[IO](accessToken).repos.listStatuses("47degrees", "github4s", "heads/master")
-
+val listStatuses = gh.repos.listStatuses("47degrees", "github4s", "heads/master")
 val response = listStatuses.unsafeRunSync()
 response.result match {
   case Left(e) => println(s"Something went wrong: ${e.getMessage}")

--- a/github4s/src/main/scala/github4s/Github.scala
+++ b/github4s/src/main/scala/github4s/Github.scala
@@ -16,19 +16,18 @@
 
 package github4s
 
-import java.util.concurrent.TimeUnit.MILLISECONDS
-import cats.effect.ConcurrentEffect
+import cats.effect.Sync
 import github4s.algebras._
 import github4s.modules._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
+import org.http4s.client.Client
 
-class Github[F[_]: ConcurrentEffect](accessToken: Option[String], timeout: Option[Duration])(
-    implicit ec: ExecutionContext
+class Github[F[_]: Sync](
+    client: Client[F],
+    accessToken: Option[String]
 ) {
 
   private lazy val module: GithubAPIs[F] =
-    new GithubAPIv3[F](accessToken, timeout.getOrElse(Duration(1000L, MILLISECONDS)))
+    new GithubAPIv3[F](client, accessToken)
 
   lazy val users: Users[F]                 = module.users
   lazy val repos: Repositories[F]          = module.repos
@@ -45,10 +44,10 @@ class Github[F[_]: ConcurrentEffect](accessToken: Option[String], timeout: Optio
 
 object Github {
 
-  def apply[F[_]: ConcurrentEffect](
-      accessToken: Option[String] = None,
-      timeout: Option[Duration] = None
-  )(implicit ec: ExecutionContext): Github[F] =
-    new Github[F](accessToken, timeout)
+  def apply[F[_]: Sync](
+      client: Client[F],
+      accessToken: Option[String] = None
+  ): Github[F] =
+    new Github[F](client, accessToken)
 
 }

--- a/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
+++ b/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
@@ -16,7 +16,6 @@
 
 package github4s.http
 
-import cats.effect.ConcurrentEffect
 import org.http4s._
 import org.http4s.MediaType
 import org.http4s.Headers
@@ -26,7 +25,7 @@ import org.http4s.headers.`Content-Type`
 
 object Http4sSyntax {
 
-  implicit class RequestOps[F[_]: ConcurrentEffect](self: Request[F]) {
+  implicit class RequestOps[F[_]](self: Request[F]) {
     def withJsonBody[T](maybeData: Option[T])(implicit enc: Encoder[T]): Request[F] =
       maybeData.fold(self)(data =>
         self

--- a/github4s/src/main/scala/github4s/interpreters/ProjectsInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/ProjectsInterpreter.scala
@@ -18,7 +18,7 @@ package github4s.interpreters
 
 import github4s.GithubResponses.GHResponse
 import github4s.algebras.Projects
-import github4s.domain.{Column, Card, Pagination, Project}
+import github4s.domain.{Card, Column, Pagination, Project}
 import github4s.http.HttpClient
 import github4s.Decoders._
 

--- a/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
+++ b/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
@@ -16,13 +16,11 @@
 
 package github4s.modules
 
-import cats.effect.ConcurrentEffect
+import cats.effect.Sync
 import github4s.algebras._
 import github4s.http.HttpClient
 import github4s.interpreters._
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
+import org.http4s.client.Client
 
 sealed trait GithubAPIs[F[_]] {
   def users: Users[F]
@@ -38,12 +36,11 @@ sealed trait GithubAPIs[F[_]] {
   def projects: Projects[F]
 }
 
-class GithubAPIv3[F[_]: ConcurrentEffect](accessToken: Option[String] = None, timeout: Duration)(
-    implicit ec: ExecutionContext
-) extends GithubAPIs[F] {
+class GithubAPIv3[F[_]: Sync](client: Client[F], accessToken: Option[String] = None)
+    extends GithubAPIs[F] {
 
-  implicit val client = new HttpClient[F](timeout)
-  implicit val at     = accessToken
+  implicit val httpClient = new HttpClient[F](client)
+  implicit val at         = accessToken
 
   override val users: Users[F]                 = new UsersInterpreter[F]
   override val repos: Repositories[F]          = new RepositoriesInterpreter[F]

--- a/github4s/src/test/scala/github4s/integration/GHActivitiesSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHActivitiesSpec.scala
@@ -19,36 +19,41 @@ package github4s.integration
 import cats.effect.IO
 import github4s.Github
 import github4s.domain._
-
 import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHActivitiesSpec extends BaseIntegrationSpec {
 
   "Activity >> Set a thread subscription" should "return expected response when a valid thread id is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .setThreadSub(validThreadId, true, false, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .setThreadSub(validThreadId, true, false, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[Subscription](response)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid thread id is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .setThreadSub(invalidThreadId, true, false, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .setThreadSub(invalidThreadId, true, false, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Activity >> ListStargazers" should "return the expected list of starrers for valid data" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStargazers(validRepoOwner, validRepoName, false, None, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStargazers(validRepoOwner, validRepoName, false, None, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Stargazer]](response, { r =>
       r.nonEmpty shouldBe true
@@ -58,10 +63,12 @@ trait GHActivitiesSpec extends BaseIntegrationSpec {
   }
 
   it should "return the expected list of starrers for valid data with dates if timeline" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStargazers(validRepoOwner, validRepoName, true, None, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStargazers(validRepoOwner, validRepoName, true, None, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Stargazer]](response, { r =>
       r.nonEmpty shouldBe true
@@ -71,20 +78,24 @@ trait GHActivitiesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for invalid repo name" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStargazers(invalidRepoName, validRepoName, false, None, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStargazers(invalidRepoName, validRepoName, false, None, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Activity >> ListStarredRepositories" should "return the expected list of starred repos" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStarredRepositories(validUsername, false, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStarredRepositories(validUsername, false, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[StarredRepository]](response, { r =>
       r.nonEmpty shouldBe true
@@ -94,10 +105,12 @@ trait GHActivitiesSpec extends BaseIntegrationSpec {
   }
 
   it should "return the expected list of starred repos with dates if timeline" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStarredRepositories(validUsername, true, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStarredRepositories(validUsername, true, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[StarredRepository]](response, { r =>
       r.nonEmpty shouldBe true
@@ -107,10 +120,12 @@ trait GHActivitiesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for invalid username" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).activities
-        .listStarredRepositories(invalidUsername, false, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).activities
+          .listStarredRepositories(invalidUsername, false, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode

--- a/github4s/src/test/scala/github4s/integration/GHAuthSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHAuthSpec.scala
@@ -25,34 +25,49 @@ trait GHAuthSpec extends BaseIntegrationSpec {
 
   "Auth >> NewAuth" should "return error on Left when invalid credential is provided" taggedAs Integration in {
 
-    val response = Github[IO]().auth
-      .newAuth(
-        validUsername,
-        invalidPassword,
-        validScopes,
-        validNote,
-        validClientId,
-        invalidClientSecret,
-        headerUserAgent
-      )
+    val response = clientResource
+      .use { client =>
+        Github[IO](client).auth
+          .newAuth(
+            validUsername,
+            invalidPassword,
+            validScopes,
+            validNote,
+            validClientId,
+            invalidClientSecret,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
   }
 
   "Auth >> AuthorizeUrl" should "return the expected URL for valid username" taggedAs Integration in {
-    val response =
-      Github[IO]().auth
-        .authorizeUrl(validClientId, validRedirectUri, validScopes)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client).auth
+          .authorizeUrl(validClientId, validRedirectUri, validScopes)
+      }
+      .unsafeRunSync()
 
     testIsRight[Authorize](response, r => r.url.contains(validRedirectUri) shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   "Auth >> GetAccessToken" should "return error on Left for invalid code value" taggedAs Integration in {
-    val response = Github[IO]().auth
-      .getAccessToken(validClientId, invalidClientSecret, "", validRedirectUri, "", headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client).auth
+          .getAccessToken(
+            validClientId,
+            invalidClientSecret,
+            "",
+            validRedirectUri,
+            "",
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsLeft(response)

--- a/github4s/src/test/scala/github4s/integration/GHGitDataSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHGitDataSpec.scala
@@ -16,8 +16,8 @@
 
 package github4s.integration
 
-import cats.effect.IO
 import cats.data.NonEmptyList
+import cats.effect.IO
 import github4s.Github
 import github4s.domain._
 import github4s.utils.{BaseIntegrationSpec, Integration}
@@ -25,8 +25,11 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHGitDataSpec extends BaseIntegrationSpec {
 
   "GitData >> GetReference" should "return a list of references" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getReference(validRepoOwner, validRepoName, "heads", headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getReference(validRepoOwner, validRepoName, "heads", headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[NonEmptyList[Ref]](response, r => r.tail.nonEmpty shouldBe true)
@@ -34,8 +37,11 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   it should "return at least one reference" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getReference(validRepoOwner, validRepoName, validRefSingle, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getReference(validRepoOwner, validRepoName, validRefSingle, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[NonEmptyList[Ref]](response, r => r.head.ref.contains(validRefSingle) shouldBe true)
@@ -43,8 +49,11 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   it should "return an error when an invalid repository name is passed" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getReference(validRepoOwner, invalidRepoName, validRefSingle, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getReference(validRepoOwner, invalidRepoName, validRefSingle, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -52,8 +61,11 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   "GitData >> GetCommit" should "return one commit" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getCommit(validRepoOwner, validRepoName, validCommitSha, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getCommit(validRepoOwner, validRepoName, validCommitSha, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[RefCommit](response, r => r.message shouldBe validCommitMsg)
@@ -61,8 +73,11 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   it should "return an error when an invalid repository name is passed" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getCommit(validRepoOwner, invalidRepoName, validCommitSha, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getCommit(validRepoOwner, invalidRepoName, validCommitSha, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -70,10 +85,18 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   "GitData >> GetTree" should "return the file tree non-recursively" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).gitData
-        .getTree(validRepoOwner, validRepoName, validCommitSha, recursive = false, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getTree(
+            validRepoOwner,
+            validRepoName,
+            validCommitSha,
+            recursive = false,
+            headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[TreeResult](
       response, { r =>
@@ -85,10 +108,12 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   it should "return the file tree recursively" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).gitData
-        .getTree(validRepoOwner, validRepoName, validCommitSha, recursive = true, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getTree(validRepoOwner, validRepoName, validCommitSha, recursive = true, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[TreeResult](
       response, { r =>
@@ -105,8 +130,17 @@ trait GHGitDataSpec extends BaseIntegrationSpec {
   }
 
   it should "return an error when an invalid repository name is passed" taggedAs Integration in {
-    val response = Github[IO](accessToken).gitData
-      .getTree(validRepoOwner, invalidRepoName, validCommitSha, recursive = false, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).gitData
+          .getTree(
+            validRepoOwner,
+            invalidRepoName,
+            validCommitSha,
+            recursive = false,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsLeft(response)

--- a/github4s/src/test/scala/github4s/integration/GHIssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHIssuesSpec.scala
@@ -24,8 +24,11 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHIssuesSpec extends BaseIntegrationSpec {
 
   "Issues >> List" should "return a list of issues" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listIssues(validRepoOwner, validRepoName, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listIssues(validRepoOwner, validRepoName, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Issue]](response, r => r.nonEmpty shouldBe true)
@@ -33,8 +36,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> Get" should "return an issue which is a PR" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .getIssue(validRepoOwner, validRepoName, validPullRequestNumber, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .getIssue(validRepoOwner, validRepoName, validPullRequestNumber, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[Issue](response, r => r.pull_request.isDefined shouldBe true)
@@ -42,8 +48,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> Search" should "return at least one issue for a valid query" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .searchIssues(validSearchQuery, validSearchParams, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .searchIssues(validSearchQuery, validSearchParams, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[SearchIssuesResult](response, { r =>
@@ -54,8 +63,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return an empty result for a non existent query string" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .searchIssues(nonExistentSearchQuery, validSearchParams, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .searchIssues(nonExistentSearchQuery, validSearchParams, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[SearchIssuesResult](response, { r =>
@@ -66,19 +78,22 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> Edit" should "edit the specified issue" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .editIssue(
-        validRepoOwner,
-        validRepoName,
-        validIssueNumber,
-        validIssueState,
-        validIssueTitle,
-        validIssueBody,
-        None,
-        validIssueLabel,
-        validAssignees,
-        headerUserAgent
-      )
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .editIssue(
+            validRepoOwner,
+            validRepoName,
+            validIssueNumber,
+            validIssueState,
+            validIssueTitle,
+            validIssueBody,
+            None,
+            validIssueLabel,
+            validAssignees,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsRight[Issue](response, { r =>
@@ -89,8 +104,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> ListLabels" should "return a list of labels" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listLabels(validRepoOwner, validRepoName, validIssueNumber, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listLabels(validRepoOwner, validRepoName, validIssueNumber, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Label]](response, r => r.nonEmpty shouldBe true)
@@ -98,16 +116,22 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> listLabelsRepository" should "return a list of labels" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listLabelsRepository(validRepoOwner, validRepoName, headerUserAgent, None)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listLabelsRepository(validRepoOwner, validRepoName, headerUserAgent, None)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Label]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
   it should "return error for an invalid repo owner" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listLabelsRepository(invalidRepoOwner, validRepoName, headerUserAgent, None)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listLabelsRepository(invalidRepoOwner, validRepoName, headerUserAgent, None)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -115,8 +139,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for an invalid repo name" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listLabelsRepository(validRepoOwner, invalidRepoName, headerUserAgent, None)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listLabelsRepository(validRepoOwner, invalidRepoName, headerUserAgent, None)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -124,14 +151,17 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> RemoveLabel" should "return a list of removed labels" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .removeLabel(
-        validRepoOwner,
-        validRepoName,
-        validIssueNumber,
-        validIssueLabel.head,
-        headerUserAgent
-      )
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .removeLabel(
+            validRepoOwner,
+            validRepoName,
+            validIssueNumber,
+            validIssueLabel.head,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsRight[List[Label]](response, r => r.nonEmpty shouldBe true)
@@ -139,8 +169,17 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "Issues >> AddLabels" should "return a list of labels" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .addLabels(validRepoOwner, validRepoName, validIssueNumber, validIssueLabel, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .addLabels(
+            validRepoOwner,
+            validRepoName,
+            validIssueNumber,
+            validIssueLabel,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsRight[List[Label]](response, r => r.nonEmpty shouldBe true)
@@ -148,8 +187,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "GHIssues >> ListAvailableAssignees" should "return a list of users" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listAvailableAssignees(validRepoOwner, validRepoName, None, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listAvailableAssignees(validRepoOwner, validRepoName, None, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.nonEmpty shouldBe true)
@@ -157,8 +199,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for an invalid repo owner" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listAvailableAssignees(invalidRepoOwner, validRepoName, None, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listAvailableAssignees(invalidRepoOwner, validRepoName, None, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -166,8 +211,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for an invalid repo name" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listAvailableAssignees(validRepoOwner, invalidRepoName, None, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listAvailableAssignees(validRepoOwner, invalidRepoName, None, headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -175,16 +223,19 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   "GHIssues >> ListMilestones" should "return a list of milestones" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listMilestones(
-        validRepoOwner,
-        validRepoName,
-        None,
-        None,
-        None,
-        None,
-        headerUserAgent
-      )
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listMilestones(
+            validRepoOwner,
+            validRepoName,
+            None,
+            None,
+            None,
+            None,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsRight[List[Milestone]](response)
@@ -192,16 +243,19 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for an invalid repo owner" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listMilestones(
-        invalidRepoOwner,
-        validRepoName,
-        None,
-        None,
-        None,
-        None,
-        headerUserAgent
-      )
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listMilestones(
+            invalidRepoOwner,
+            validRepoName,
+            None,
+            None,
+            None,
+            None,
+            headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -209,8 +263,11 @@ trait GHIssuesSpec extends BaseIntegrationSpec {
   }
 
   it should "return error for an invalid repo name" taggedAs Integration in {
-    val response = Github[IO](accessToken).issues
-      .listMilestones(validRepoOwner, invalidRepoName, None, None, None, None, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .listMilestones(validRepoOwner, invalidRepoName, None, None, None, None, headerUserAgent)
+      }
       .unsafeRunSync()
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode

--- a/github4s/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
@@ -24,40 +24,48 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHOrganizationsSpec extends BaseIntegrationSpec {
 
   "Organization >> ListMembers" should "return the expected list of users" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).organizations
-        .listMembers(validRepoOwner, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).organizations
+          .listMembers(validRepoOwner, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for an invalid org" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).organizations
-        .listMembers(invalidUsername, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).organizations
+          .listMembers(invalidUsername, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Organization >> ListOutsideCollaborators" should "return expected list of users" ignore {
-    val response =
-      Github[IO](accessToken).organizations
-        .listOutsideCollaborators(validOrganizationName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).organizations
+          .listOutsideCollaborators(validOrganizationName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for an invalid org" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).organizations
-        .listOutsideCollaborators(invalidOrganizationName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).organizations
+          .listOutsideCollaborators(invalidOrganizationName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode

--- a/github4s/src/test/scala/github4s/integration/GHProjectsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHProjectsSpec.scala
@@ -24,88 +24,105 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHProjectsSpec extends BaseIntegrationSpec {
 
   "Project >> ListProjects" should "return the expected projects when a valid org is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listProjects(validRepoOwner, headers = headerUserAgent ++ headerAccept)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listProjects(validRepoOwner, headers = headerUserAgent ++ headerAccept)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Project]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid org is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listProjects(invalidRepoName, headers = headerUserAgent ++ headerAccept)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listProjects(invalidRepoName, headers = headerUserAgent ++ headerAccept)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
   }
 
   "Project >> ListProjectsRepository" should "return the expected projects when a valid owner and repo are provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listProjectsRepository(
-          validRepoOwner,
-          validRepoName,
-          headers = headerUserAgent ++ headerAccept
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listProjectsRepository(
+            validRepoOwner,
+            validRepoName,
+            headers = headerUserAgent ++ headerAccept
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Project]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listProjectsRepository(
-          validRepoOwner,
-          invalidRepoName,
-          headers = headerUserAgent ++ headerAccept
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listProjectsRepository(
+            validRepoOwner,
+            invalidRepoName,
+            headers = headerUserAgent ++ headerAccept
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
   }
 
   it should "return error when an invalid owner is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listProjectsRepository(
-          invalidRepoOwner,
-          validRepoName,
-          headers = headerUserAgent ++ headerAccept
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listProjectsRepository(
+            invalidRepoOwner,
+            validRepoName,
+            headers = headerUserAgent ++ headerAccept
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Project >> ListColumns" should "return the expected column when a valid project id is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listColumns(validProjectId, headers = headerUserAgent ++ headerAccept)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listColumns(validProjectId, headers = headerUserAgent ++ headerAccept)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Column]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid project id is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listColumns(invalidProjectId, headers = headerUserAgent ++ headerAccept)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listColumns(invalidProjectId, headers = headerUserAgent ++ headerAccept)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Project >> ListCards" should "return the expected cards when a valid column id is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).projects
-      .listCards(validColumnId, headers = headerUserAgent ++ headerAccept)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listCards(validColumnId, headers = headerUserAgent ++ headerAccept)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Card]](response, r => r.nonEmpty shouldBe true)
@@ -113,10 +130,12 @@ trait GHProjectsSpec extends BaseIntegrationSpec {
   }
 
   it should "return error when an invalid column id is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).projects
-        .listCards(invalidColumnId, headers = headerUserAgent ++ headerAccept)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).projects
+          .listCards(invalidColumnId, headers = headerUserAgent ++ headerAccept)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode

--- a/github4s/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
@@ -24,192 +24,230 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHPullRequestsSpec extends BaseIntegrationSpec {
 
   "PullRequests >> Get" should "return a right response when a valid pr number is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .getPullRequest(
-          validRepoOwner,
-          validRepoName,
-          validPullRequestNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .getPullRequest(
+            validRepoOwner,
+            validRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[PullRequest](response)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return an error when a valid issue number is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .getPullRequest(validRepoOwner, validRepoName, validIssueNumber, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .getPullRequest(
+            validRepoOwner,
+            validRepoName,
+            validIssueNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   it should "return an error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .getPullRequest(
-          validRepoOwner,
-          invalidRepoName,
-          validPullRequestNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .getPullRequest(
+            validRepoOwner,
+            invalidRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "PullRequests >> List" should "return a right response when valid repo is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listPullRequests(
-          validRepoOwner,
-          validRepoName,
-          pagination = Some(Pagination(1, 10)),
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listPullRequests(
+            validRepoOwner,
+            validRepoName,
+            pagination = Some(Pagination(1, 10)),
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequest]](response)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return a right response when a valid repo is provided but not all pull requests have body" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listPullRequests(
-          "lloydmeta",
-          "gh-test-repo",
-          List(PRFilterOpen),
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listPullRequests(
+            "lloydmeta",
+            "gh-test-repo",
+            List(PRFilterOpen),
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequest]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return a non empty list when valid repo and some filters are provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listPullRequests(
-          validRepoOwner,
-          validRepoName,
-          List(PRFilterAll, PRFilterSortCreated, PRFilterOrderAsc),
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listPullRequests(
+            validRepoOwner,
+            validRepoName,
+            List(PRFilterAll, PRFilterSortCreated, PRFilterOrderAsc),
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequest]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listPullRequests(validRepoOwner, invalidRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listPullRequests(validRepoOwner, invalidRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "PullRequests >> ListFiles" should "return a right response when a valid repo is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listFiles(validRepoOwner, validRepoName, validPullRequestNumber, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listFiles(
+            validRepoOwner,
+            validRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequestFile]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return a right response when a valid repo is provided and not all files have 'patch'" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listFiles("scala", "scala", 4877, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listFiles("scala", "scala", 4877, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequestFile]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listFiles(
-          validRepoOwner,
-          invalidRepoName,
-          validPullRequestNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listFiles(
+            validRepoOwner,
+            invalidRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "PullRequests >> ListReviews" should "return a right response when a valid pr is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listReviews(
-          validRepoOwner,
-          validRepoName,
-          validPullRequestNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listReviews(
+            validRepoOwner,
+            validRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[List[PullRequestReview]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .listReviews(
-          validRepoOwner,
-          invalidRepoName,
-          validPullRequestNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .listReviews(
+            validRepoOwner,
+            invalidRepoName,
+            validPullRequestNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "PullRequests >> GetReview" should "return a right response when a valid pr review is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .getReview(
-          validRepoOwner,
-          validRepoName,
-          validPullRequestNumber,
-          validPullRequestReviewNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .getReview(
+            validRepoOwner,
+            validRepoName,
+            validPullRequestNumber,
+            validPullRequestReviewNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsRight[PullRequestReview](response, r => r.id shouldBe validPullRequestReviewNumber)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).pullRequests
-        .getReview(
-          validRepoOwner,
-          invalidRepoName,
-          validPullRequestNumber,
-          validPullRequestReviewNumber,
-          headers = headerUserAgent
-        )
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).pullRequests
+          .getReview(
+            validRepoOwner,
+            invalidRepoName,
+            validPullRequestNumber,
+            validPullRequestReviewNumber,
+            headers = headerUserAgent
+          )
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode

--- a/github4s/src/test/scala/github4s/integration/GHReposSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHReposSpec.scala
@@ -25,48 +25,59 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHReposSpec extends BaseIntegrationSpec {
 
   "Repos >> Get" should "return the expected name when a valid repo is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .get(validRepoOwner, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .get(validRepoOwner, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[Repository](response, r => r.name shouldBe validRepoName)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid repo name is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .get(validRepoOwner, invalidRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .get(validRepoOwner, invalidRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListOrgRepos" should "return the expected repos when a valid org is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listOrgRepos(validRepoOwner, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listOrgRepos(validRepoOwner, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Repository]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid org is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listOrgRepos(invalidRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listOrgRepos(invalidRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListUserRepos" should "return the expected repos when a valid user is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listUserRepos(validUsername, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listUserRepos(validUsername, headers = headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Repository]](response, r => r.nonEmpty shouldBe true)
@@ -74,8 +85,11 @@ trait GHReposSpec extends BaseIntegrationSpec {
   }
 
   it should "return error when an invalid user is passed" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listUserRepos(invalidUsername, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listUserRepos(invalidUsername, headers = headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsLeft(response)
@@ -83,103 +97,136 @@ trait GHReposSpec extends BaseIntegrationSpec {
   }
 
   "Repos >> GetContents" should "return the expected contents when valid path is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .getContents(validRepoOwner, validRepoName, validFilePath, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .getContents(validRepoOwner, validRepoName, validFilePath, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[NonEmptyList[Content]](response, r => r.head.path shouldBe validFilePath)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid path is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .getContents(validRepoOwner, validRepoName, invalidFilePath, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .getContents(validRepoOwner, validRepoName, invalidFilePath, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListCommits" should "return the expected list of commits for valid data" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listCommits(validRepoOwner, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listCommits(validRepoOwner, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Commit]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for invalid repo name" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listCommits(invalidRepoName, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listCommits(invalidRepoName, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListBranches" should "return the expected list of branches for valid data" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listBranches(validRepoOwner, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listBranches(validRepoOwner, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Branch]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for invalid repo name" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listBranches(invalidRepoName, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listBranches(invalidRepoName, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListContributors" should "return the expected list of contributors for valid data" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listContributors(validRepoOwner, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listContributors(validRepoOwner, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r shouldNot be(empty))
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for invalid repo name" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listContributors(invalidRepoName, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listContributors(invalidRepoName, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListCollaborators" should "return the expected list of collaborators for valid data" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listCollaborators(validRepoOwner, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listCollaborators(validRepoOwner, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r shouldNot be(empty))
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error for invalid repo name" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).repos
-        .listCollaborators(invalidRepoName, validRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listCollaborators(invalidRepoName, validRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> GetStatus" should "return a combined status" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .getCombinedStatus(validRepoOwner, validRepoName, validRefSingle, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .getCombinedStatus(
+            validRepoOwner,
+            validRepoName,
+            validRefSingle,
+            headers = headerUserAgent
+          )
+      }
       .unsafeRunSync()
 
     testIsRight[CombinedStatus](
@@ -190,16 +237,23 @@ trait GHReposSpec extends BaseIntegrationSpec {
   }
 
   it should "return an error when an invalid ref is passed" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .getCombinedStatus(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .getCombinedStatus(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
+      }
       .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Repos >> ListStatus" should "return a non empty list when a valid ref is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listStatuses(validRepoOwner, validRepoName, validCommitSha, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listStatuses(validRepoOwner, validRepoName, validCommitSha, headers = headerUserAgent)
+      }
       .unsafeRunSync()
 
     testIsRight[List[Status]](response, r => r.nonEmpty shouldBe true)
@@ -207,9 +261,13 @@ trait GHReposSpec extends BaseIntegrationSpec {
   }
 
   it should "return an error when an invalid ref is provided" taggedAs Integration in {
-    val response = Github[IO](accessToken).repos
-      .listStatuses(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).repos
+          .listStatuses(validRepoOwner, validRepoName, invalidRef, headers = headerUserAgent)
+      }
       .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }

--- a/github4s/src/test/scala/github4s/integration/GHTeamsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHTeamsSpec.scala
@@ -23,20 +23,25 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHTeamsSpec extends BaseIntegrationSpec {
   "Team >> ListTeams" should "return the expected teams when a valid org is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).teams
-        .listTeams(validRepoOwner, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).teams
+          .listTeams(validRepoOwner, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[Team]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error when an invalid org is passed" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).teams
-        .listTeams(invalidRepoName, headers = headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).teams
+          .listTeams(invalidRepoName, headers = headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }

--- a/github4s/src/test/scala/github4s/integration/GHUsersSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/GHUsersSpec.scala
@@ -24,63 +24,83 @@ import github4s.utils.{BaseIntegrationSpec, Integration}
 trait GHUsersSpec extends BaseIntegrationSpec {
 
   "Users >> Get" should "return the expected login for a valid username" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).users.get(validUsername, headerUserAgent).unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .get(validUsername, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[User](response, r => r.login shouldBe validUsername)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error on Left for invalid username" taggedAs Integration in {
-    val response = Github[IO](accessToken).users
-      .get(invalidUsername, headerUserAgent)
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .get(invalidUsername, headerUserAgent)
+      }
       .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }
 
   "Users >> GetAuth" should "return error on Left when no accessToken is provided" taggedAs Integration in {
     val response =
-      Github[IO]().users.getAuth(headerUserAgent).unsafeRunSync()
+      clientResource
+        .use(client => Github[IO](client).users.getAuth(headerUserAgent))
+        .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe unauthorizedStatusCode
   }
 
   "Users >> GetUsers" should "return users for a valid since value" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).users
-        .getUsers(validSinceInt, None, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .getUsers(validSinceInt, None, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return an empty list when a invalid since value is provided" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).users
-        .getUsers(invalidSinceInt, None, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .getUsers(invalidSinceInt, None, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.isEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   "Users >> GetFollowing" should "return the expected following list for a valid username" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).users
-        .getFollowing(validUsername, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .getFollowing(validUsername, headerUserAgent)
+      }
+      .unsafeRunSync()
 
     testIsRight[List[User]](response, r => r.nonEmpty shouldBe true)
     response.statusCode shouldBe okStatusCode
   }
 
   it should "return error on Left for invalid username" taggedAs Integration in {
-    val response =
-      Github[IO](accessToken).users
-        .getFollowing(invalidUsername, headerUserAgent)
-        .unsafeRunSync()
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).users
+          .getFollowing(invalidUsername, headerUserAgent)
+      }
+      .unsafeRunSync()
+
     testIsLeft(response)
     response.statusCode shouldBe notFoundStatusCode
   }

--- a/github4s/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
@@ -16,9 +16,11 @@
 
 package github4s.utils
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO, Resource}
 import github4s.GithubResponses.GHResponse
 import github4s.integration._
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, Ignore, Inspectors, Tag}
@@ -49,10 +51,13 @@ abstract class BaseIntegrationSpec
     with Matchers
     with Inspectors
     with TestData {
-  override implicit val executionContext: ExecutionContext =
+
+  override val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
-  implicit val ioContextShift = IO.contextShift(executionContext)
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+
+  val clientResource: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](executionContext).resource
 
   def accessToken: Option[String] = sys.env.get("GITHUB4S_ACCESS_TOKEN")
 

--- a/github4s/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseSpec.scala
@@ -16,24 +16,23 @@
 
 package github4s.utils
 
+import cats.effect.IO
 import github4s.GithubResponses.GHResponse
 import github4s.domain.Pagination
 import github4s.http.HttpClient
 import io.circe.{Decoder, Encoder}
+import org.http4s.client.Client
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
-
-import scala.concurrent.duration.Duration
-import java.util.concurrent.TimeUnit
 
 trait BaseSpec extends AnyFlatSpec with Matchers with TestData with MockFactory {
 
   implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
   implicit val io = cats.effect.IO.contextShift(ec)
-  import cats.effect.IO
 
-  class HttpClientTest extends HttpClient[IO](Duration(1000, TimeUnit.MILLISECONDS))
+  @com.github.ghik.silencer.silent("deprecated")
+  class HttpClientTest extends HttpClient[IO](mock[Client[IO]])
 
   def httpClientMockGet[Out](
       url: String,

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -451,7 +451,8 @@ trait TestData extends DummyGithubUrls {
       login = "juanpedromoreno",
       id = 4879373,
       node_id = "MDQ6VXNlcjQ4NzkzNzM",
-      avatar_url = "https://avatars0.githubusercontent.com/u/4879373?u=14c42c4477d6f407c17ad5275501f9347208a9df&v=4",
+      avatar_url =
+        "https://avatars0.githubusercontent.com/u/4879373?u=14c42c4477d6f407c17ad5275501f9347208a9df&v=4",
       gravatar_id = None,
       url = "https://api.github.com/users/juanpedromoreno",
       html_url = "https://github.com/juanpedromoreno",

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -33,6 +33,7 @@ object ProjectPlugin extends AutoPlugin {
       val http4s: String     = "0.21.1"
       val scalamock: String  = "4.4.0"
       val scalaTest: String  = "3.1.1"
+      val silencer: String   = "1.6.0"
     }
 
     lazy val micrositeSettings = Seq(
@@ -84,7 +85,9 @@ object ProjectPlugin extends AutoPlugin {
         %%("scalatest", V.scalaTest) % Test,
         "org.mock-server"            % "mockserver-netty" % "5.9.0" % Test excludeAll ExclusionRule(
           "com.twitter"
-        )
+        ),
+        compilerPlugin("com.github.ghik" % "silencer-plugin" % V.silencer cross CrossVersion.full),
+        "com.github.ghik" % "silencer-lib" % V.silencer % Provided cross CrossVersion.full
       ),
       libraryDependencies ++= (CrossVersion.partialVersion(scalaBinaryVersion.value) match {
         case Some((2, 13)) => Seq.empty[ModuleID]


### PR DESCRIPTION
This change avoids creating and tearing down a client on each call.

If this looks okay, I'll modify the docs as well.

cc @tovbinm