### PR TITLE
Introduces custom GitHub configuration

### DIFF
--- a/docs/docs/docs.md
+++ b/docs/docs/docs.md
@@ -59,21 +59,6 @@ val user1 = Github[IO](httpClient, accessToken).users.get("rafaparadela")
 
 `user1` in this case is a `IO[GHResponse[User]]`.
 
-It is also possible to pass a custom GitHub configuration (e.g. a GitHub Enterprise server endpoint)
-by declaring an implicit `GithubConfig` value in the scope:
-
-```scala mdoc:silent
-import github4s.{Github, GithubConfig}
-
-implicit val config =
-  GithubConfig(baseUrl = "custom GitHub server API endpoint",  authorizeUrl = ???, accessTokenUrl = ???)
-
-val accessToken = sys.env.get("GITHUB4S_ACCESS_TOKEN")
-val github = Github[IO](httpClient, accessToken)
-
-```
-Please refer your GitHub server docs for exact configuration values.
-
 ### Using `F[_]: cats.effect.Sync`
 
 Any type with a `cats.effect.Sync` instance can be used with this example, such as
@@ -197,7 +182,30 @@ object ProgramEvalWithHeaders {
 }
 ```
 
+## Using github4s with GitHub Enterprise
+
+By default `Github` instances are configured for the [public GitHub][public-github] endpoints via a fallback
+`GithubConfig` instance which is picked up by the `Github` constructor if there's no other `GithubConfig` in the scope. 
+
+It is also possible to pass a custom GitHub configuration (e.g. for a particular [GitHub Enterprise][github-enterprise]
+server). To override the default configuration values declare a custom `GithubConfig` instance in an appropriate
+scope:
+```scala mdoc:silent
+import github4s.{Github, GithubConfig}
+
+implicit val config = GithubConfig(
+  baseUrl = ???,       // default: "https://api.github.com/"
+  authorizeUrl = ???,  // default: "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
+  accessTokenUrl = ??? // default: "https://github.com/login/oauth/access_token"
+)
+
+val github = Github[IO](httpClient, "")
+```
+Please refer your GitHub Enterprise server docs for exact URL values for `baseUrl`, `authorizeUrl` and `accessTokenUrl`.
+
 [access-token]: https://github.com/settings/tokens
 [cats-sync]: https://typelevel.org/cats-effect/typeclasses/sync.html
 [monix-task]: https://monix.io/docs/3x/eval/task.html
 [http4s-client]: https://http4s.org/v0.21/client/
+[public-github]: https://github.com
+[github-enterprise]: https://github.com/enterprise

--- a/docs/docs/docs.md
+++ b/docs/docs/docs.md
@@ -59,6 +59,21 @@ val user1 = Github[IO](httpClient, accessToken).users.get("rafaparadela")
 
 `user1` in this case is a `IO[GHResponse[User]]`.
 
+It is also possible to pass a custom GitHub configuration (e.g. a GitHub Enterprise server endpoint)
+by declaring an implicit `GithubConfig` value in the scope:
+
+```scala mdoc:silent
+import github4s.{Github, GithubConfig}
+
+implicit val config =
+  GithubConfig(baseUrl = "custom GitHub server API endpoint",  authorizeUrl = ???, accessTokenUrl = ???)
+
+val accessToken = sys.env.get("GITHUB4S_ACCESS_TOKEN")
+val github = Github[IO](httpClient, accessToken)
+
+```
+Please refer your GitHub server docs for exact configuration values.
+
 ### Using `F[_]: cats.effect.Sync`
 
 Any type with a `cats.effect.Sync` instance can be used with this example, such as

--- a/docs/docs/docs.md
+++ b/docs/docs/docs.md
@@ -199,7 +199,7 @@ implicit val config = GithubConfig(
   accessTokenUrl = ??? // default: "https://github.com/login/oauth/access_token"
 )
 
-val github = Github[IO](httpClient, "")
+val github = Github[IO](httpClient, None)
 ```
 Please refer your GitHub Enterprise server docs for exact URL values for `baseUrl`, `authorizeUrl` and `accessTokenUrl`.
 

--- a/docs/docs/docs.md
+++ b/docs/docs/docs.md
@@ -194,9 +194,9 @@ scope:
 import github4s.{Github, GithubConfig}
 
 implicit val config = GithubConfig(
-  baseUrl = ???,       // default: "https://api.github.com/"
-  authorizeUrl = ???,  // default: "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
-  accessTokenUrl = ??? // default: "https://github.com/login/oauth/access_token"
+  baseUrl = "",       // default: "https://api.github.com/"
+  authorizeUrl = "",  // default: "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
+  accessTokenUrl = "" // default: "https://github.com/login/oauth/access_token"
 )
 
 val github = Github[IO](httpClient, None)

--- a/github4s/src/main/resources/application.conf
+++ b/github4s/src/main/resources/application.conf
@@ -1,3 +1,0 @@
-github.baseUrl = "https://api.github.com/"
-github.authorizeUrl = "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
-github.accessTokenUrl = "https://github.com/login/oauth/access_token"

--- a/github4s/src/main/scala/github4s/Github.scala
+++ b/github4s/src/main/scala/github4s/Github.scala
@@ -18,7 +18,6 @@ package github4s
 
 import cats.effect.Sync
 import github4s.algebras._
-import github4s.http.GithubConfig
 import github4s.modules._
 import org.http4s.client.Client
 

--- a/github4s/src/main/scala/github4s/Github.scala
+++ b/github4s/src/main/scala/github4s/Github.scala
@@ -47,6 +47,6 @@ object Github {
   def apply[F[_]: Sync](
       client: Client[F],
       accessToken: Option[String] = None
-  )(implicit urls: GithubConfig): Github[F] =
+  )(implicit config: GithubConfig): Github[F] =
     new Github[F](client, accessToken)
 }

--- a/github4s/src/main/scala/github4s/Github.scala
+++ b/github4s/src/main/scala/github4s/Github.scala
@@ -18,13 +18,14 @@ package github4s
 
 import cats.effect.Sync
 import github4s.algebras._
+import github4s.http.GithubConfig
 import github4s.modules._
 import org.http4s.client.Client
 
 class Github[F[_]: Sync](
     client: Client[F],
     accessToken: Option[String]
-) {
+)(implicit config: GithubConfig) {
 
   private lazy val module: GithubAPIs[F] =
     new GithubAPIv3[F](client, accessToken)
@@ -47,7 +48,6 @@ object Github {
   def apply[F[_]: Sync](
       client: Client[F],
       accessToken: Option[String] = None
-  ): Github[F] =
+  )(implicit urls: GithubConfig): Github[F] =
     new Github[F](client, accessToken)
-
 }

--- a/github4s/src/main/scala/github4s/Github.scala
+++ b/github4s/src/main/scala/github4s/Github.scala
@@ -27,8 +27,7 @@ class Github[F[_]: Sync](
     accessToken: Option[String]
 )(implicit config: GithubConfig) {
 
-  private lazy val module: GithubAPIs[F] =
-    new GithubAPIv3[F](client, accessToken)
+  private lazy val module: GithubAPIs[F] = new GithubAPIv3[F](client, config, accessToken)
 
   lazy val users: Users[F]                 = module.users
   lazy val repos: Repositories[F]          = module.repos

--- a/github4s/src/main/scala/github4s/GithubConfig.scala
+++ b/github4s/src/main/scala/github4s/GithubConfig.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package github4s.http
+package github4s
 
 final case class GithubConfig(baseUrl: String, authorizeUrl: String, accessTokenUrl: String)
 

--- a/github4s/src/main/scala/github4s/http/GithubConfig.scala
+++ b/github4s/src/main/scala/github4s/http/GithubConfig.scala
@@ -16,9 +16,14 @@
 
 package github4s.http
 
-case class GithubAPIv3Config(
-    baseUrl: String = "https://api.github.com/",
-    authorizeUrl: String =
-      "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s",
-    accessTokenUrl: String = "https://github.com/login/oauth/access_token"
-)
+final case class GithubConfig(baseUrl: String, authorizeUrl: String, accessTokenUrl: String)
+
+object GithubConfig {
+  implicit val default: GithubConfig =
+    GithubConfig(
+      baseUrl = "https://api.github.com/",
+      authorizeUrl =
+        "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s",
+      accessTokenUrl = "https://github.com/login/oauth/access_token"
+    )
+}

--- a/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
+++ b/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
@@ -49,8 +49,8 @@ object Http4sSyntax {
       (self.headers.map(kv => Header(kv._1, kv._2)) ++
         self.authHeader.map(kv => Header(kv._1, kv._2))).toList
 
-    def toUri(urls: GithubConfig): Uri =
-      Uri.fromString(self.url).getOrElse(Uri.unsafeFromString(urls.baseUrl)) =?
+    def toUri(config: GithubConfig): Uri =
+      Uri.fromString(self.url).getOrElse(Uri.unsafeFromString(config.baseUrl)) =?
         self.params.map(kv => (kv._1, List(kv._2)))
 
   }

--- a/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
+++ b/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
@@ -16,11 +16,10 @@
 
 package github4s.http
 
-import org.http4s._
-import org.http4s.MediaType
-import org.http4s.Headers
-import io.circe.{Encoder, Json, Printer}
+import github4s.GithubConfig
 import io.circe.syntax._
+import io.circe.{Encoder, Json, Printer}
+import org.http4s._
 import org.http4s.headers.`Content-Type`
 
 object Http4sSyntax {

--- a/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
+++ b/github4s/src/main/scala/github4s/http/Http4sSyntax.scala
@@ -49,7 +49,7 @@ object Http4sSyntax {
       (self.headers.map(kv => Header(kv._1, kv._2)) ++
         self.authHeader.map(kv => Header(kv._1, kv._2))).toList
 
-    def toUri(urls: GithubAPIv3Config): Uri =
+    def toUri(urls: GithubConfig): Uri =
       Uri.fromString(self.url).getOrElse(Uri.unsafeFromString(urls.baseUrl)) =?
         self.params.map(kv => (kv._1, List(kv._2)))
 

--- a/github4s/src/main/scala/github4s/http/HttpClient.scala
+++ b/github4s/src/main/scala/github4s/http/HttpClient.scala
@@ -27,9 +27,9 @@ import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
 
-class HttpClient[F[_]: Sync](client: Client[F]) {
+class HttpClient[F[_]: Sync](client: Client[F])(implicit config: GithubConfig) {
 
-  val urls: GithubAPIv3Config = GithubAPIv3Config()
+  val urls: GithubConfig = config
 
   def get[Res: Decoder](
       accessToken: Option[String] = None,

--- a/github4s/src/main/scala/github4s/http/HttpClient.scala
+++ b/github4s/src/main/scala/github4s/http/HttpClient.scala
@@ -27,7 +27,7 @@ import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
 
-class HttpClient[F[_]: Sync](client: Client[F], val urls: GithubConfig) {
+class HttpClient[F[_]: Sync](client: Client[F], val config: GithubConfig) {
 
   def get[Res: Decoder](
       accessToken: Option[String] = None,
@@ -128,14 +128,14 @@ class HttpClient[F[_]: Sync](client: Client[F], val urls: GithubConfig) {
   val defaultPage: Int    = 1
   val defaultPerPage: Int = 30
 
-  private def buildURL(method: String): String = urls.baseUrl + method
+  private def buildURL(method: String): String = config.baseUrl + method
 
   private def run[Req: Encoder, Res: Decoder](request: RequestBuilder[Req]): F[GHResponse[Res]] = {
     client
       .run(
         Request[F]()
           .withMethod(request.httpVerb)
-          .withUri(request.toUri(urls))
+          .withUri(request.toUri(config))
           .withHeaders(request.toHeaderList: _*)
           .withJsonBody(request.data)
       )

--- a/github4s/src/main/scala/github4s/http/HttpClient.scala
+++ b/github4s/src/main/scala/github4s/http/HttpClient.scala
@@ -27,9 +27,7 @@ import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
 
-class HttpClient[F[_]: Sync](client: Client[F])(implicit config: GithubConfig) {
-
-  val urls: GithubConfig = config
+class HttpClient[F[_]: Sync](client: Client[F], val urls: GithubConfig) {
 
   def get[Res: Decoder](
       accessToken: Option[String] = None,

--- a/github4s/src/main/scala/github4s/http/HttpClient.scala
+++ b/github4s/src/main/scala/github4s/http/HttpClient.scala
@@ -19,10 +19,11 @@ package github4s.http
 import cats.effect.Sync
 import cats.syntax.either._
 import cats.syntax.functor._
-import io.circe.{Decoder, Encoder}
+import github4s.GithubConfig
 import github4s.GithubResponses.{GHResponse, JsonParsingException}
 import github4s.domain.Pagination
 import github4s.http.Http4sSyntax._
+import io.circe.{Decoder, Encoder}
 import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client

--- a/github4s/src/main/scala/github4s/interpreters/AuthInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/AuthInterpreter.scala
@@ -56,7 +56,7 @@ class AuthInterpreter[F[_]: Applicative](
     val result: GHResponse[Authorize] =
       GHResponse(
         result = Authorize(
-          client.urls.authorizeUrl.format(client_id, redirect_uri, scopes.mkString(","), state),
+          client.config.authorizeUrl.format(client_id, redirect_uri, scopes.mkString(","), state),
           state
         ).asRight,
         statusCode = 200,
@@ -74,7 +74,7 @@ class AuthInterpreter[F[_]: Applicative](
       headers: Map[String, String] = Map()
   ): F[GHResponse[OAuthToken]] =
     client.postOAuth[NewOAuthRequest, OAuthToken](
-      url = client.urls.accessTokenUrl,
+      url = client.config.accessTokenUrl,
       headers = headers,
       data = NewOAuthRequest(client_id, client_secret, code, redirect_uri, state)
     )

--- a/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
+++ b/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
@@ -36,11 +36,13 @@ sealed trait GithubAPIs[F[_]] {
   def projects: Projects[F]
 }
 
-class GithubAPIv3[F[_]: Sync](client: Client[F], accessToken: Option[String] = None)(
-    implicit config: GithubConfig
+class GithubAPIv3[F[_]: Sync](
+    client: Client[F],
+    config: GithubConfig,
+    accessToken: Option[String] = None
 ) extends GithubAPIs[F] {
 
-  implicit val httpClient = new HttpClient[F](client)
+  implicit val httpClient = new HttpClient[F](client, config)
   implicit val at         = accessToken
 
   override val users: Users[F]                 = new UsersInterpreter[F]

--- a/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
+++ b/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
@@ -18,7 +18,7 @@ package github4s.modules
 
 import cats.effect.Sync
 import github4s.algebras._
-import github4s.http.HttpClient
+import github4s.http.{GithubConfig, HttpClient}
 import github4s.interpreters._
 import org.http4s.client.Client
 
@@ -36,8 +36,9 @@ sealed trait GithubAPIs[F[_]] {
   def projects: Projects[F]
 }
 
-class GithubAPIv3[F[_]: Sync](client: Client[F], accessToken: Option[String] = None)
-    extends GithubAPIs[F] {
+class GithubAPIv3[F[_]: Sync](client: Client[F], accessToken: Option[String] = None)(
+    implicit config: GithubConfig
+) extends GithubAPIs[F] {
 
   implicit val httpClient = new HttpClient[F](client)
   implicit val at         = accessToken

--- a/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
+++ b/github4s/src/main/scala/github4s/modules/GithubAPIs.scala
@@ -17,8 +17,9 @@
 package github4s.modules
 
 import cats.effect.Sync
+import github4s.GithubConfig
 import github4s.algebras._
-import github4s.http.{GithubConfig, HttpClient}
+import github4s.http.HttpClient
 import github4s.interpreters._
 import org.http4s.client.Client
 

--- a/github4s/src/test/scala/github4s/unit/AuthSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/AuthSpec.scala
@@ -71,7 +71,7 @@ class AuthSpec extends BaseSpec {
     )
 
     implicit val httpClientMock = httpClientMockPostOAuth[NewOAuthRequest, OAuthToken](
-      url = "https://github.com/login/oauth/access_token",
+      url = dummyUrls.accessTokenUrl,
       req = request,
       response = response
     )

--- a/github4s/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseSpec.scala
@@ -17,14 +17,15 @@
 package github4s.utils
 
 import cats.effect.IO
+import github4s.GithubConfig
 import github4s.GithubResponses.GHResponse
 import github4s.domain.Pagination
-import github4s.http.{GithubConfig, HttpClient}
+import github4s.http.HttpClient
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 trait BaseSpec extends AnyFlatSpec with Matchers with TestData with MockFactory {
 

--- a/github4s/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseSpec.scala
@@ -19,7 +19,7 @@ package github4s.utils
 import cats.effect.IO
 import github4s.GithubResponses.GHResponse
 import github4s.domain.Pagination
-import github4s.http.HttpClient
+import github4s.http.{GithubConfig, HttpClient}
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.scalamock.scalatest.MockFactory
@@ -32,7 +32,7 @@ trait BaseSpec extends AnyFlatSpec with Matchers with TestData with MockFactory 
   implicit val io = cats.effect.IO.contextShift(ec)
 
   @com.github.ghik.silencer.silent("deprecated")
-  class HttpClientTest extends HttpClient[IO](mock[Client[IO]])
+  class HttpClientTest extends HttpClient[IO](mock[Client[IO]], implicitly[GithubConfig])
 
   def httpClientMockGet[Out](
       url: String,

--- a/github4s/src/test/scala/github4s/utils/DummyGithubUrls.scala
+++ b/github4s/src/test/scala/github4s/utils/DummyGithubUrls.scala
@@ -16,11 +16,11 @@
 
 package github4s.utils
 
-import github4s.http.GithubAPIv3Config
+import github4s.http.GithubConfig
 
 trait DummyGithubUrls {
 
-  implicit val dummyUrls: GithubAPIv3Config = GithubAPIv3Config(
+  implicit val dummyUrls: GithubConfig = GithubConfig(
     baseUrl = "http://127.0.0.1:9999/",
     authorizeUrl = "http://127.0.0.1:9999/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s",
     accessTokenUrl = "http://127.0.0.1:9999/login/oauth/access_token"

--- a/github4s/src/test/scala/github4s/utils/DummyGithubUrls.scala
+++ b/github4s/src/test/scala/github4s/utils/DummyGithubUrls.scala
@@ -16,7 +16,7 @@
 
 package github4s.utils
 
-import github4s.http.GithubConfig
+import github4s.GithubConfig
 
 trait DummyGithubUrls {
 


### PR DESCRIPTION
Fixes #379

Adds an implicit `config` parameter to `Github` instance which allows to override the default configuration by injecting a custom implicit `GithubConfig` instance into a current scope:

```scala
val client: Client[IO] = ???
val accessToken: String = ???
implicit val myConfig = GithubConfig(baseUrl = "https://<whatever>/api/v3", ...)

val github = Github[IO](client, Some(accessToken)) // `myConfig` will be picked up while in the scope
```