### PR TITLE
Renames Token Env Var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+      G4S_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+      G4S_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val github4s =
       buildInfoKeys := Seq[BuildInfoKey](
         name,
         version,
-        "token" -> sys.env.getOrElse("GITHUB_TOKEN", "")
+        "token" -> sys.env.getOrElse("G4S_TOKEN", "")
       ),
       buildInfoPackage := "github4s"
     )

--- a/docs/docs/activity.md
+++ b/docs/docs/activity.md
@@ -33,7 +33,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -127,7 +127,7 @@ The first step we need to take in order to run the tests is a valid token which 
 environment variable:
 
 ```bash
-export GITHUB_TOKEN=aaaa
+export G4S_TOKEN=aaaa
 ```
 
 You can create a token on Github: <https://github.com/settings/tokens>.

--- a/docs/docs/docs.md
+++ b/docs/docs/docs.md
@@ -53,7 +53,7 @@ As an introductory example, we can get a user with the following:
 
 ```scala mdoc:silent
 import github4s.Github
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val user1 = Github[IO](httpClient, accessToken).users.get("rafaparadela")
 ```
 

--- a/docs/docs/gist.md
+++ b/docs/docs/gist.md
@@ -31,7 +31,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 
@@ -49,7 +49,7 @@ To create a gist:
 ```scala mdoc:compile-only
 import github4s.domain.GistFile
 val gistfiles = Map(
-  "token.scala" -> GistFile("val accessToken = sys.env.get(\"GITHUB_TOKEN\")"),
+  "token.scala" -> GistFile("val accessToken = sys.env.get(\"G4S_TOKEN\")"),
   "gh4s.scala"  -> GistFile("val gh = Github(accessToken)")
 )
 val newGist = gh.gists.newGist("Github4s entry point", public = true, gistfiles)
@@ -111,7 +111,7 @@ To edit a gist (change description, update content of _token.scala_, rename _gh4
 ```scala mdoc:compile-only
 import github4s.domain.EditGistFile
 val editfiles = Map(
-  "token.scala" -> Some(EditGistFile("lazy val accessToken = sys.env.get(\"GITHUB_TOKEN\")")),
+  "token.scala" -> Some(EditGistFile("lazy val accessToken = sys.env.get(\"G4S_TOKEN\")")),
   "gh4s.scala"  -> Some(EditGistFile("val gh = Github(accessToken)", Some("GH4s.scala"))),
   "token.class"  -> None
 )

--- a/docs/docs/git_data.md
+++ b/docs/docs/git_data.md
@@ -40,7 +40,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/issue.md
+++ b/docs/docs/issue.md
@@ -48,7 +48,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/organization.md
+++ b/docs/docs/organization.md
@@ -32,7 +32,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/project.md
+++ b/docs/docs/project.md
@@ -40,7 +40,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/pull_request.md
+++ b/docs/docs/pull_request.md
@@ -36,7 +36,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/repository.md
+++ b/docs/docs/repository.md
@@ -44,7 +44,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/team.md
+++ b/docs/docs/team.md
@@ -30,7 +30,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/docs/docs/user.md
+++ b/docs/docs/user.md
@@ -31,7 +31,7 @@ val httpClient: Client[IO] = {
   JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
 }
 
-val accessToken = sys.env.get("GITHUB_TOKEN")
+val accessToken = sys.env.get("G4S_TOKEN")
 val gh = Github[IO](httpClient, accessToken)
 ```
 

--- a/github4s/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
@@ -42,7 +42,7 @@ class IntegrationSpec
 
 object Integration
     extends Tag(
-      if (sys.env.get("GITHUB_TOKEN").isDefined) ""
+      if (sys.env.get("G4S_TOKEN").exists(_.nonEmpty)) ""
       else classOf[Ignore].getName
     )
 
@@ -59,7 +59,7 @@ abstract class BaseIntegrationSpec
 
   val clientResource: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](executionContext).resource
 
-  def accessToken: Option[String] = sys.env.get("GITHUB_TOKEN")
+  def accessToken: Option[String] = sys.env.get("G4S_TOKEN")
 
   def testIsRight[A](response: GHResponse[A], f: A => Assertion = (_: A) => succeed): Assertion = {
     response.result.isRight shouldBe true

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -131,7 +131,7 @@ object ProjectPlugin extends AutoPlugin {
           case _             => withStripedLinter
         }) :+ "-language:higherKinds"
       },
-      orgGithubTokenSetting := "GITHUB_TOKEN",
+      orgGithubTokenSetting := "G4S_TOKEN",
       orgBadgeListSetting := List(
         TravisBadge.apply(_),
         GitterBadge.apply(_),


### PR DESCRIPTION
`GITHUB_TOKEN` is added by GH actions by default.

Fixes #396 