### PR TITLE
Adds micrositeGithubToken settings

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -42,6 +42,7 @@ object ProjectPlugin extends AutoPlugin {
       micrositeGithubOwner := "47degrees",
       micrositeGithubRepo := "github4s",
       micrositeAuthor := "Github4s contributors",
+      micrositeGithubToken := Option(System.getenv().get("GITHUB_TOKEN")),
       micrositeCompilingDocsTool := WithMdoc,
       micrositePushSiteWith := GitHub4s,
       micrositeOrganizationHomepage := "https://github.com/47degrees/github4s/blob/master/AUTHORS.md",


### PR DESCRIPTION
This PR provides a GitHub token through the `micrositeGithubToken` setting for pushing with github4s.

Formerly provided by sbt-org-policies.

