### PR TITLE
Do not depend on the http4s blaze client

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -77,11 +77,12 @@ object ProjectPlugin extends AutoPlugin {
         "io.circe"              %% "circe-generic"       % V.circe,
         "io.circe"              %% "circe-literal"       % V.circe,
         "com.github.marklister" %% "base64"              % V.base64,
-        "org.http4s"            %% "http4s-blaze-client" % V.http4s,
+        "org.http4s"            %% "http4s-client"       % V.http4s,
         "org.http4s"            %% "http4s-circe"        % V.http4s,
         "io.circe"              %% "circe-parser"        % V.circe % Test,
         "org.scalamock"         %% "scalamock"           % V.scalamock % Test,
         "org.scalatest"         %% "scalatest"           % V.scalatest % Test,
+        "org.http4s"            %% "http4s-blaze-client" % V.http4s % Test,
         "com.github.ghik"       % "silencer-lib"         % V.silencer % Provided cross CrossVersion.full,
         compilerPlugin("com.github.ghik" % "silencer-plugin" % V.silencer cross CrossVersion.full)
       ),


### PR DESCRIPTION
We do not need to depend on a specific implementation of the http4s client since we're asking the user to provide one.