### PR TITLE
Fixes oauth/access_token Interpreter

### DIFF
--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -59,7 +59,6 @@ object Encoders {
   implicit val encoderSubscriptionRequest: Encoder[SubscriptionRequest] =
     deriveEncoder[SubscriptionRequest]
   implicit val encoderNewAuthRequest: Encoder[NewAuthRequest]     = deriveEncoder[NewAuthRequest]
-  implicit val encoderNewOAuthRequest: Encoder[NewOAuthRequest]   = deriveEncoder[NewOAuthRequest]
   implicit val encoderNewGistRequest: Encoder[NewGistRequest]     = deriveEncoder[NewGistRequest]
   implicit val encoderEditGistRequest: Encoder[EditGistRequest]   = deriveEncoder[EditGistRequest]
   implicit val encoderNewIssueRequest: Encoder[NewIssueRequest]   = deriveEncoder[NewIssueRequest]

--- a/github4s/src/main/scala/github4s/domain/Authorization.scala
+++ b/github4s/src/main/scala/github4s/domain/Authorization.scala
@@ -39,11 +39,3 @@ final case class OAuthToken(
     token_type: String,
     scope: String
 )
-
-final case class NewOAuthRequest(
-    client_id: String,
-    client_secret: String,
-    code: String,
-    redirect_uri: String,
-    state: String
-)

--- a/github4s/src/main/scala/github4s/http/HttpClient.scala
+++ b/github4s/src/main/scala/github4s/http/HttpClient.scala
@@ -98,15 +98,15 @@ class HttpClient[F[_]: Sync](client: Client[F], val config: GithubConfig) {
   ): F[GHResponse[Res]] =
     run[Req, Res](RequestBuilder(buildURL(method)).postMethod.withHeaders(headers).withData(data))
 
-  def postOAuth[Req: Encoder, Res: Decoder](
+  def postOAuth[Res: Decoder](
       url: String,
       headers: Map[String, String] = Map.empty,
-      data: Req
+      params: Map[String, String] = Map.empty
   ): F[GHResponse[Res]] =
-    run[Req, Res](
+    run[Unit, Res](
       RequestBuilder(url).postMethod
         .withHeaders(Map("Accept" -> "application/json") ++ headers)
-        .withData(data)
+        .withParams(params)
     )
 
   def delete(

--- a/github4s/src/main/scala/github4s/interpreters/AuthInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/AuthInterpreter.scala
@@ -73,9 +73,15 @@ class AuthInterpreter[F[_]: Applicative](implicit
       state: String,
       headers: Map[String, String]
   ): F[GHResponse[OAuthToken]] =
-    client.postOAuth[NewOAuthRequest, OAuthToken](
+    client.postOAuth[OAuthToken](
       url = client.config.accessTokenUrl,
       headers = headers,
-      data = NewOAuthRequest(client_id, client_secret, code, redirect_uri, state)
+      Map(
+        "client_id"     -> client_id,
+        "client_secret" -> client_secret,
+        "code"          -> code,
+        "redirect_uri"  -> redirect_uri,
+        "state"         -> state
+      )
     )
 }

--- a/github4s/src/test/scala/github4s/integration/AuthSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/AuthSpec.scala
@@ -70,8 +70,8 @@ trait AuthSpec extends BaseIntegrationSpec {
       }
       .unsafeRunSync()
 
-    testIsLeft[GHError.BasicError, OAuthToken](response)
-    response.statusCode shouldBe notFoundStatusCode
+    testIsLeft[GHError.JsonParsingError, OAuthToken](response)
+    response.statusCode shouldBe okStatusCode
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/AuthSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/AuthSpec.scala
@@ -62,17 +62,8 @@ class AuthSpec extends BaseSpec {
     val response: IO[GHResponse[OAuthToken]] =
       IO(GHResponse(oAuthToken.asRight, okStatusCode, Map.empty))
 
-    val request = NewOAuthRequest(
-      validClientId,
-      invalidClientSecret,
-      validCode,
-      validRedirectUri,
-      validAuthState
-    )
-
     implicit val httpClientMock = httpClientMockPostOAuth[NewOAuthRequest, OAuthToken](
       url = dummyConfig.accessTokenUrl,
-      req = request,
       response = response
     )
 

--- a/github4s/src/test/scala/github4s/unit/AuthSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/AuthSpec.scala
@@ -62,7 +62,7 @@ class AuthSpec extends BaseSpec {
     val response: IO[GHResponse[OAuthToken]] =
       IO(GHResponse(oAuthToken.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockPostOAuth[NewOAuthRequest, OAuthToken](
+    implicit val httpClientMock = httpClientMockPostOAuth[OAuthToken](
       url = dummyConfig.accessTokenUrl,
       response = response
     )

--- a/github4s/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseSpec.scala
@@ -94,7 +94,7 @@ trait BaseSpec extends AnyFlatSpec with Matchers with TestData with MockFactory 
     httpClientMock
   }
 
-  def httpClientMockPostOAuth[In, Out](
+  def httpClientMockPostOAuth[Out](
       url: String,
       response: IO[GHResponse[Out]]
   ): HttpClient[IO] = {

--- a/github4s/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/src/test/scala/github4s/utils/BaseSpec.scala
@@ -96,16 +96,14 @@ trait BaseSpec extends AnyFlatSpec with Matchers with TestData with MockFactory 
 
   def httpClientMockPostOAuth[In, Out](
       url: String,
-      req: In,
       response: IO[GHResponse[Out]]
   ): HttpClient[IO] = {
     val httpClientMock = mock[HttpClientTest]
     (httpClientMock
-      .postOAuth[In, Out](_: String, _: Map[String, String], _: In)(
-        _: Encoder[In],
+      .postOAuth[Out](_: String, _: Map[String, String], _: Map[String, String])(
         _: Decoder[Out]
       ))
-      .expects(url, headerUserAgent, req, *, *)
+      .expects(url, headerUserAgent, *, *)
       .returns(response)
     httpClientMock
   }


### PR DESCRIPTION
This PR fixes the [oauth/access_token](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github).

Essentially, the `POST` information needs to be passed by URL parameters, instead of in the body, as you can see in [this section](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#parameters-1).