### PR TITLE
Turn id fields into longs

### DIFF
--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -85,7 +85,7 @@ object Decoders {
   implicit val decodeStatusRepository: Decoder[StatusRepository] = {
     Decoder.instance { c =>
       for {
-        id          <- c.downField("id").as[Int]
+        id          <- c.downField("id").as[Long]
         name        <- c.downField("name").as[String]
         full_name   <- c.downField("full_name").as[String]
         owner       <- c.downField("owner").as[Option[User]]
@@ -112,7 +112,7 @@ object Decoders {
 
     Decoder.instance { c =>
       for {
-        id                <- c.downField("id").as[Int]
+        id                <- c.downField("id").as[Long]
         name              <- c.downField("name").as[String]
         full_name         <- c.downField("full_name").as[String]
         owner             <- c.downField("owner").as[User]

--- a/github4s/src/main/scala/github4s/algebras/Activities.scala
+++ b/github4s/src/main/scala/github4s/algebras/Activities.scala
@@ -31,7 +31,7 @@ trait Activities[F[_]] {
    * @return GHResponse with the Subscription
    */
   def setThreadSub(
-      id: Int,
+      id: Long,
       subscribed: Boolean,
       ignored: Boolean,
       headers: Map[String, String] = Map()

--- a/github4s/src/main/scala/github4s/algebras/Issues.scala
+++ b/github4s/src/main/scala/github4s/algebras/Issues.scala
@@ -193,7 +193,7 @@ trait Issues[F[_]] {
   def editComment(
       owner: String,
       repo: String,
-      id: Int,
+      id: Long,
       body: String,
       headers: Map[String, String] = Map()
   ): F[GHResponse[Comment]]
@@ -210,7 +210,7 @@ trait Issues[F[_]] {
   def deleteComment(
       owner: String,
       repo: String,
-      id: Int,
+      id: Long,
       headers: Map[String, String] = Map()
   ): F[GHResponse[Unit]]
 

--- a/github4s/src/main/scala/github4s/algebras/Projects.scala
+++ b/github4s/src/main/scala/github4s/algebras/Projects.scala
@@ -66,7 +66,7 @@ trait Projects[F[_]] {
    * @return GHResponse with the list of columns belonging to this project id
    */
   def listColumns(
-      project_id: Int,
+      project_id: Long,
       pagination: Option[Pagination] = None,
       headers: Map[String, String] = Map()
   ): F[GHResponse[List[Column]]]
@@ -82,7 +82,7 @@ trait Projects[F[_]] {
    * @return GHResponse with the list of cards belonging to this column id
    */
   def listCards(
-      column_id: Int,
+      column_id: Long,
       archived_state: Option[String] = None,
       pagination: Option[Pagination] = None,
       headers: Map[String, String] = Map()

--- a/github4s/src/main/scala/github4s/algebras/PullRequests.scala
+++ b/github4s/src/main/scala/github4s/algebras/PullRequests.scala
@@ -134,7 +134,7 @@ trait PullRequests[F[_]] {
       owner: String,
       repo: String,
       pullRequest: Int,
-      review: Int,
+      review: Long,
       headers: Map[String, String] = Map()
   ): F[GHResponse[PullRequestReview]]
 

--- a/github4s/src/main/scala/github4s/algebras/Repositories.scala
+++ b/github4s/src/main/scala/github4s/algebras/Repositories.scala
@@ -281,7 +281,7 @@ trait Repositories[F[_]] {
    * @return a GHResponse with List[Release]
    */
   def getRelease(
-      releaseId: Int,
+      releaseId: Long,
       owner: String,
       repo: String,
       headers: Map[String, String] = Map()

--- a/github4s/src/main/scala/github4s/domain/Authorization.scala
+++ b/github4s/src/main/scala/github4s/domain/Authorization.scala
@@ -17,7 +17,7 @@
 package github4s.domain
 
 final case class Authorization(
-    id: Int,
+    id: Long,
     url: String,
     token: String
 )

--- a/github4s/src/main/scala/github4s/domain/Issue.scala
+++ b/github4s/src/main/scala/github4s/domain/Issue.scala
@@ -42,7 +42,7 @@ final case class Issue(
 )
 
 final case class Label(
-    id: Option[Int],
+    id: Option[Long],
     name: String,
     url: String,
     color: String,

--- a/github4s/src/main/scala/github4s/domain/Issue.scala
+++ b/github4s/src/main/scala/github4s/domain/Issue.scala
@@ -19,7 +19,7 @@ package github4s.domain
 import java.time.ZonedDateTime
 
 final case class Issue(
-    id: Int,
+    id: Long,
     title: String,
     body: Option[String],
     url: String,
@@ -80,7 +80,7 @@ final case class EditIssueRequest(
 )
 
 final case class Comment(
-    id: Int,
+    id: Long,
     url: String,
     html_url: String,
     body: String,
@@ -95,7 +95,7 @@ final case class Milestone(
     url: String,
     html_url: String,
     labels_url: String,
-    id: Int,
+    id: Long,
     node_id: String,
     number: Int,
     state: String,

--- a/github4s/src/main/scala/github4s/domain/Project.scala
+++ b/github4s/src/main/scala/github4s/domain/Project.scala
@@ -21,7 +21,7 @@ final case class Project(
     url: String,
     html_url: String,
     columns_url: String,
-    id: Int,
+    id: Long,
     node_id: String,
     name: String,
     body: Option[String],
@@ -35,7 +35,7 @@ final case class Project(
 
 final case class Creator(
     login: String,
-    id: Int,
+    id: Long,
     node_id: String,
     avatar_url: String,
     gravatar_id: Option[String],
@@ -58,7 +58,7 @@ final case class Column(
     url: String,
     project_url: String,
     cards_url: String,
-    id: Int,
+    id: Long,
     node_id: String,
     name: String,
     created_at: String,
@@ -68,7 +68,7 @@ final case class Column(
 final case class Card(
     url: String,
     project_url: String,
-    id: Int,
+    id: Long,
     node_id: String,
     note: Option[String],
     archived: Boolean,

--- a/github4s/src/main/scala/github4s/domain/PullRequest.scala
+++ b/github4s/src/main/scala/github4s/domain/PullRequest.scala
@@ -17,7 +17,7 @@
 package github4s.domain
 
 final case class PullRequest(
-    id: Int,
+    id: Long,
     number: Int,
     state: String,
     title: String,
@@ -107,7 +107,7 @@ final case class NewPullRequestData(title: String, body: String) extends NewPull
 final case class NewPullRequestIssue(issue: Int)                 extends NewPullRequest
 
 final case class PullRequestReview(
-    id: Int,
+    id: Long,
     user: Option[User],
     body: String,
     commit_id: String,

--- a/github4s/src/main/scala/github4s/domain/Repository.scala
+++ b/github4s/src/main/scala/github4s/domain/Repository.scala
@@ -17,7 +17,7 @@
 package github4s.domain
 
 final case class Repository(
-    id: Int,
+    id: Long,
     name: String,
     full_name: String,
     owner: User,
@@ -61,7 +61,7 @@ final case class RepoUrls(
 )
 
 final case class Release(
-    id: Int,
+    id: Long,
     tag_name: String,
     target_commitish: String,
     name: String,
@@ -147,7 +147,7 @@ final case class NewStatusRequest(
 )
 
 final case class StatusRepository(
-    id: Int,
+    id: Long,
     name: String,
     full_name: String,
     owner: Option[User],

--- a/github4s/src/main/scala/github4s/domain/Team.scala
+++ b/github4s/src/main/scala/github4s/domain/Team.scala
@@ -17,7 +17,7 @@
 package github4s.domain
 
 final case class Team(
-    id: Int,
+    id: Long,
     node_id: String,
     url: String,
     html_url: String,

--- a/github4s/src/main/scala/github4s/domain/User.scala
+++ b/github4s/src/main/scala/github4s/domain/User.scala
@@ -17,7 +17,7 @@
 package github4s.domain
 
 final case class User(
-    id: Int,
+    id: Long,
     login: String,
     avatar_url: String,
     html_url: String,

--- a/github4s/src/main/scala/github4s/interpreters/ActivitiesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/ActivitiesInterpreter.scala
@@ -29,7 +29,7 @@ class ActivitiesInterpreter[F[_]](implicit client: HttpClient[F], accessToken: O
   private val timelineHeader = ("Accept" -> "application/vnd.github.v3.star+json")
 
   override def setThreadSub(
-      id: Int,
+      id: Long,
       subscribed: Boolean,
       ignored: Boolean,
       headers: Map[String, String]

--- a/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
@@ -126,7 +126,7 @@ class IssuesInterpreter[F[_]](implicit client: HttpClient[F], accessToken: Optio
   override def editComment(
       owner: String,
       repo: String,
-      id: Int,
+      id: Long,
       body: String,
       headers: Map[String, String]
   ): F[GHResponse[Comment]] =
@@ -141,7 +141,7 @@ class IssuesInterpreter[F[_]](implicit client: HttpClient[F], accessToken: Optio
   override def deleteComment(
       owner: String,
       repo: String,
-      id: Int,
+      id: Long,
       headers: Map[String, String]
   ): F[GHResponse[Unit]] =
     client.delete(accessToken, s"repos/$owner/$repo/issues/comments/$id", headers)

--- a/github4s/src/main/scala/github4s/interpreters/ProjectsInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/ProjectsInterpreter.scala
@@ -57,7 +57,7 @@ class ProjectsInterpreter[F[_]](implicit
     )
 
   override def listColumns(
-      project_id: Int,
+      project_id: Long,
       pagination: Option[Pagination],
       headers: Map[String, String]
   ): F[GHResponse[List[Column]]] =
@@ -70,7 +70,7 @@ class ProjectsInterpreter[F[_]](implicit
     )
 
   override def listCards(
-      column_id: Int,
+      column_id: Long,
       archived_state: Option[String],
       pagination: Option[Pagination],
       headers: Map[String, String]

--- a/github4s/src/main/scala/github4s/interpreters/PullRequestsInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/PullRequestsInterpreter.scala
@@ -103,7 +103,7 @@ class PullRequestsInterpreter[F[_]](implicit client: HttpClient[F], accessToken:
       owner: String,
       repo: String,
       pullRequest: Int,
-      review: Int,
+      review: Long,
       headers: Map[String, String]
   ): F[GHResponse[PullRequestReview]] =
     client.get[PullRequestReview](

--- a/github4s/src/main/scala/github4s/interpreters/RepositoriesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/RepositoriesInterpreter.scala
@@ -226,7 +226,7 @@ class RepositoriesInterpreter[F[_]](implicit client: HttpClient[F], accessToken:
       .get[Option[Release]](accessToken, s"repos/$owner/$repo/releases/latest", headers, Map.empty)
 
   override def getRelease(
-      releaseId: Int,
+      releaseId: Long,
       owner: String,
       repo: String,
       headers: Map[String, String]

--- a/github4s/src/test/scala/github4s/unit/DecodersSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/DecodersSpec.scala
@@ -72,7 +72,7 @@ class DecodersSpec extends AnyFlatSpec with Matchers with FakeResponses {
   }
 
   case class Foo(a: Int)
-  it should "return a valid NonEmtpyList for a valid JSON" in {
+  it should "return a valid NonEmptyList for a valid JSON" in {
     decode[NonEmptyList[Foo]]("""{"a": 1}""") shouldBe Right(NonEmptyList(Foo(1), Nil))
   }
 

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -120,7 +120,7 @@ trait TestData {
 
   val validPullRequestFileSha      = "f80f79cafbe3f2ba71311b82e1171e73bd37a470"
   val validPullRequestNumber       = 1
-  val validPullRequestReviewNumber = 39318789
+  val validPullRequestReviewNumber = 39318789L
   val validMergeCommitSha          = "e5bd3914e2e596debea16f433f57875b5b90bcd6"
 
   val validHead   = "test-pr-issue"
@@ -323,9 +323,9 @@ trait TestData {
       urls = Map()
     )
   )
-  val validThreadId = 219647953
+  val validThreadId = 219647953L
 
-  val invalidThreadId = 0
+  val invalidThreadId = 0L
 
   val subscription = Subscription(
     subscribed = true,
@@ -337,8 +337,8 @@ trait TestData {
   )
   val validCommentBody   = "the comment"
   val invalidIssueNumber = 0
-  val validCommentId     = 1
-  val invalidCommentId   = 0
+  val validCommentId     = 1L
+  val invalidCommentId   = 0L
 
   val comment = Comment(
     validCommentId,
@@ -461,8 +461,8 @@ trait TestData {
     parent = null
   )
 
-  val validProjectId   = 4115271
-  val invalidProjectId = 11111
+  val validProjectId   = 4115271L
+  val invalidProjectId = 11111L
 
   val project = Project(
     owner_url = "https://api.github.com/orgs/47degrees",
@@ -512,8 +512,8 @@ trait TestData {
     updated_at = "2019-07-04T09:39:01Z"
   )
 
-  val validColumnId   = 8271018
-  val invalidColumnId = -32
+  val validColumnId   = 8271018L
+  val invalidColumnId = -32L
 
   val card = Card(
     url = "https://api.github.com/projects/columns/cards/34323195",


### PR DESCRIPTION
Migrate all the id fields in github objects from `int` to use `long`. Solves an issue when the ids go over the max int such as `2170205650` which we saw as an id for the labels. I am not exactly sure of the `ids` are global to all repos but they do have really large numbers and hence decided to update all the other id fields for the client

Previous
```scala
final case class SomeGitObject(
  id: Int
  ....
)
```

Now
```scala
final case class SomeGitObject(
  id: Long
  ....
)
```