### PR TITLE
Added issue label api

### DIFF
--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -63,6 +63,7 @@ object Encoders {
   implicit val encoderEditGistRequest: Encoder[EditGistRequest]   = deriveEncoder[EditGistRequest]
   implicit val encoderNewIssueRequest: Encoder[NewIssueRequest]   = deriveEncoder[NewIssueRequest]
   implicit val encoderEditIssueRequest: Encoder[EditIssueRequest] = deriveEncoder[EditIssueRequest]
+  implicit val encoderLabel: Encoder[Label]                       = deriveEncoder[Label]
   implicit val encoderCommentData: Encoder[CommentData]           = deriveEncoder[CommentData]
   implicit val encoderNewReleaseRequest: Encoder[NewReleaseRequest] =
     deriveEncoder[NewReleaseRequest]

--- a/github4s/src/main/scala/github4s/algebras/Issues.scala
+++ b/github4s/src/main/scala/github4s/algebras/Issues.scala
@@ -261,7 +261,7 @@ trait Issues[F[_]] {
       owner: String,
       repo: String,
       label: Label,
-      headers: Map[String, String]
+      headers: Map[String, String] = Map()
   ): F[GHResponse[Label]]
 
   /**
@@ -277,7 +277,7 @@ trait Issues[F[_]] {
       owner: String,
       repo: String,
       label: Label,
-      headers: Map[String, String]
+      headers: Map[String, String] = Map()
   ): F[GHResponse[Label]]
 
   /**
@@ -293,7 +293,7 @@ trait Issues[F[_]] {
       owner: String,
       repo: String,
       label: String,
-      headers: Map[String, String]
+      headers: Map[String, String] = Map()
   ): F[GHResponse[Unit]]
 
   /**

--- a/github4s/src/main/scala/github4s/algebras/Issues.scala
+++ b/github4s/src/main/scala/github4s/algebras/Issues.scala
@@ -249,6 +249,54 @@ trait Issues[F[_]] {
   ): F[GHResponse[List[Label]]]
 
   /**
+   * Create label in repository
+   *
+   * @param owner of the repo
+   * @param repo name of the repo
+   * @param label label to create in the repository
+   * @param headers optional user headers to include in the request
+   * @return a GHResponse with the created Label.
+   */
+  def createLabel(
+      owner: String,
+      repo: String,
+      label: Label,
+      headers: Map[String, String]
+  ): F[GHResponse[Label]]
+
+  /**
+   * Update label in repository
+   *
+   * @param owner of the repo
+   * @param repo name of the repo
+   * @param label label to update in the repository
+   * @param headers optional user headers to include in the request
+   * @return a GHResponse with the updated Label.
+   */
+  def updateLabel(
+      owner: String,
+      repo: String,
+      label: Label,
+      headers: Map[String, String]
+  ): F[GHResponse[Label]]
+
+  /**
+   * Delete label for repository
+   *
+   * @param owner of the repo
+   * @param repo name of the repo
+   * @param label the name of the label to delete from the repository
+   * @param headers optional user headers to include in the request
+   * @return a Unit GHResponse
+   */
+  def deleteLabel(
+      owner: String,
+      repo: String,
+      label: String,
+      headers: Map[String, String]
+  ): F[GHResponse[Unit]]
+
+  /**
    * Add the specified labels to an Issue
    *
    * @param owner of the repo

--- a/github4s/src/main/scala/github4s/domain/Issue.scala
+++ b/github4s/src/main/scala/github4s/domain/Issue.scala
@@ -44,7 +44,8 @@ final case class Issue(
 final case class Label(
     id: Option[Long],
     name: String,
-    url: String,
+    description: Option[String],
+    url: Option[String],
     color: String,
     default: Option[Boolean]
 )

--- a/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
@@ -211,8 +211,6 @@ class IssuesInterpreter[F[_]](implicit client: HttpClient[F], accessToken: Optio
       headers
     )
 
-
-
   override def addLabels(
       owner: String,
       repo: String,

--- a/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/IssuesInterpreter.scala
@@ -173,6 +173,46 @@ class IssuesInterpreter[F[_]](implicit client: HttpClient[F], accessToken: Optio
       pagination = pagination
     )
 
+  override def createLabel(
+      owner: String,
+      repo: String,
+      label: Label,
+      headers: Map[String, String]
+  ): F[GHResponse[Label]] =
+    client.post[Label, Label](
+      accessToken,
+      s"repos/$owner/$repo/labels",
+      headers,
+      label
+    )
+
+  override def updateLabel(
+      owner: String,
+      repo: String,
+      label: Label,
+      headers: Map[String, String]
+  ): F[GHResponse[Label]] =
+    client.patch[Label, Label](
+      accessToken,
+      s"repos/$owner/$repo/labels/${label.name}",
+      headers,
+      label
+    )
+
+  override def deleteLabel(
+      owner: String,
+      repo: String,
+      label: String,
+      headers: Map[String, String]
+  ): F[GHResponse[Unit]] =
+    client.delete(
+      accessToken,
+      s"repos/$owner/$repo/labels/$label",
+      headers
+    )
+
+
+
   override def addLabels(
       owner: String,
       repo: String,

--- a/github4s/src/test/scala/github4s/integration/IssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/IssuesSpec.scala
@@ -179,6 +179,56 @@ trait IssuesSpec extends BaseIntegrationSpec {
     response.statusCode shouldBe okStatusCode
   }
 
+  "Issues >> CreateLabel" should "return a created label" taggedAs Integration in {
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .createLabel(
+            validRepoOwner,
+            validRepoName,
+            validRepoLabel,
+            headerUserAgent
+          )
+      }
+      .unsafeRunSync()
+
+    testIsRight[Label](response, r => r.name shouldBe validRepoLabel.name)
+    response.statusCode shouldBe okStatusCode
+  }
+
+  "Issues >> UpdateLabel" should "return a updated label" taggedAs Integration in {
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .updateLabel(
+            validRepoOwner,
+            validRepoName,
+            validRepoLabel,
+            headerUserAgent
+          )
+      }
+      .unsafeRunSync()
+
+    testIsRight[Label](response, r => r.name shouldBe validRepoLabel.name)
+    response.statusCode shouldBe okStatusCode
+  }
+
+  "Issues >> DeleteLabel" should "return a valid status code" taggedAs Integration in {
+    val response = clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues
+          .deleteLabel(
+            validRepoOwner,
+            validRepoName,
+            validRepoLabel.name,
+            headerUserAgent
+          )
+      }
+      .unsafeRunSync()
+
+    response.statusCode shouldBe noContentStatusCode
+  }
+
   "Issues >> AddLabels" should "return a list of labels" taggedAs Integration in {
     val response = clientResource
       .use { client =>

--- a/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
@@ -294,7 +294,6 @@ class IssuesSpec extends BaseSpec {
     )
   }
 
-
   "Issues.AddLabels" should "call httpClient.post with the right parameters" in {
     val response: IO[GHResponse[List[Label]]] =
       IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))

--- a/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
@@ -234,6 +234,67 @@ class IssuesSpec extends BaseSpec {
     issues.listLabels(validRepoOwner, validRepoName, validIssueNumber, None, headerUserAgent)
   }
 
+  "Issues.CreateLabel" should "call httpClient.post with the right parameters" in {
+    val response: IO[GHResponse[Label]] =
+      IO(GHResponse(validRepoLabel.asRight, okStatusCode, Map.empty))
+
+    val request = validRepoLabel
+
+    implicit val httpClientMock = httpClientMockPost[Label, Label](
+      url = s"repos/$validRepoOwner/$validRepoName/labels",
+      req = request,
+      response = response
+    )
+
+    val issues = new IssuesInterpreter[IO]
+    issues.createLabel(
+      validRepoOwner,
+      validRepoName,
+      validRepoLabel,
+      headerUserAgent
+    )
+  }
+
+  "Issues.UpdateLabel" should "call httpClient.patch with the right parameters" in {
+    val response: IO[GHResponse[Label]] =
+      IO(GHResponse(validRepoLabel.asRight, okStatusCode, Map.empty))
+
+    val request = validRepoLabel
+
+    implicit val httpClientMock = httpClientMockPatch[Label, Label](
+      url = s"repos/$validRepoOwner/$validRepoName/labels/${validRepoLabel.name}",
+      req = request,
+      response = response
+    )
+
+    val issues = new IssuesInterpreter[IO]
+    issues.updateLabel(
+      validRepoOwner,
+      validRepoName,
+      validRepoLabel,
+      headerUserAgent
+    )
+  }
+
+  "Issues.DeleteLabel" should "call httpClient.delete with the right parameters" in {
+    val response: IO[GHResponse[Unit]] =
+      IO(GHResponse(().asRight, noContentStatusCode, Map.empty))
+
+    implicit val httpClientMock = httpClientMockDelete(
+      url = s"repos/$validRepoOwner/$validRepoName/labels/${validRepoLabel.name}",
+      response = response
+    )
+
+    val issues = new IssuesInterpreter[IO]
+    issues.deleteLabel(
+      validRepoOwner,
+      validRepoName,
+      validRepoLabel.name,
+      headerUserAgent
+    )
+  }
+
+
   "Issues.AddLabels" should "call httpClient.post with the right parameters" in {
     val response: IO[GHResponse[List[Label]]] =
       IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -100,6 +100,16 @@ trait TestData {
   val validIssueState  = "closed"
   val validIssueLabel  = List("bug", "code review")
   val validAssignees   = List(validUsername)
+  val validRepoLabelColor = "f29513"
+  val validRepoLabelName = "bug"
+  val validRepoLabel    = Label(
+    name = validRepoLabelName,
+    color = validRepoLabelColor,
+    id = None,
+    description = None,
+    url = None,
+    default = None
+  )
 
   val encoding = Some("utf-8")
 
@@ -205,8 +215,9 @@ trait TestData {
   val label = Label(
     id = Some(1),
     name = validIssueLabel.head,
-    url = githubApiUrl,
-    color = "",
+    description = None,
+    url = Some(githubApiUrl),
+    color = validRepoLabelColor,
     default = None
   )
 

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -94,15 +94,15 @@ trait TestData {
     OwnerParamInRepository(s"$validRepoOwner/$validRepoName")
   )
 
-  val validIssueNumber = 48
-  val validIssueTitle  = "Sample Title"
-  val validIssueBody   = "Sample Body"
-  val validIssueState  = "closed"
-  val validIssueLabel  = List("bug", "code review")
-  val validAssignees   = List(validUsername)
+  val validIssueNumber    = 48
+  val validIssueTitle     = "Sample Title"
+  val validIssueBody      = "Sample Body"
+  val validIssueState     = "closed"
+  val validIssueLabel     = List("bug", "code review")
+  val validAssignees      = List(validUsername)
   val validRepoLabelColor = "f29513"
-  val validRepoLabelName = "bug"
-  val validRepoLabel    = Label(
+  val validRepoLabelName  = "bug"
+  val validRepoLabel = Label(
     name = validRepoLabelName,
     color = validRepoLabelColor,
     id = None,

--- a/microsite/docs/issue.md
+++ b/microsite/docs/issue.md
@@ -22,6 +22,9 @@ with Github4s, you can interact with:
   - [Delete a comment](#delete-a-comment)
 - [Labels](#labels)
   - [List labels for this repository](#list-labels-for-this-repository)
+  - [Create a label](#create-a-label)
+  - [Update a label](#update-a-label)
+  - [Delete a label](#delete-a-label)
   - [List labels](#list-labels)
   - [Add labels](#add-labels)
   - [Remove a label](#remove-a-label)
@@ -309,6 +312,87 @@ The `result` on the right is the corresponding [List[Label]][issue-scala]
 
 See [the API doc](https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository) for full reference.
 
+### Create a label
+
+You can create label for an repository with the following parameters:
+
+ - the repository coordinates (`owner` and `name` of the repository).
+ - `label`: Label for create (`name`, `color` and optional field `desctiption`) 
+
+ To create label:
+
+```scala mdoc:compile-only
+val label = Label(
+    name = "bug",
+    color = "ffffff",
+    id = None,
+    description = None,
+    url = None,
+    default = None
+)
+val createLabel = gh.issues.createLabel("47degrees", "github4s", label)
+val response = createLabel.unsafeRunSync()
+response.result match {
+  case Left(e) => println(s"Something went wrong: ${e.getMessage}")
+  case Right(r) => println(r)
+}
+```
+
+The `result` on the right is the corresponding created [Label][issue-scala]
+
+See [the API doc](https://developer.github.com/v3/issues/labels/#create-a-label) for full reference.
+
+### Update a label
+
+You can update existing label for an repository with the following parameters:
+
+ - the repository coordinates (`owner` and `name` of the repository).
+ - `label`: Label for update (`name`, `color` and optional field `desctiption`) 
+
+ To update label:
+
+```scala mdoc:compile-only
+val label = Label(
+    name = "bug",
+    color = "ffffff",
+    id = None,
+    description = None,
+    url = None,
+    default = None
+)
+val updateLabel = gh.issues.updateLabel("47degrees", "github4s", label)
+val response = updateLabel.unsafeRunSync()
+response.result match {
+  case Left(e) => println(s"Something went wrong: ${e.getMessage}")
+  case Right(r) => println(r)
+}
+```
+
+The `result` on the right is the corresponding updated [Label][issue-scala]
+
+See [the API doc](https://developer.github.com/v3/issues/labels/#update-a-label) for full reference.
+
+### Delete a label
+
+You can delete existing label for an repository with the following parameters:
+
+ - the repository coordinates (`owner` and `name` of the repository).
+ - `label`: The existing label name
+
+ To delete label:
+
+```scala mdoc:compile-only
+val deleteLabel = gh.issues.deleteLabel("47degrees", "github4s", "bug")
+val response = deleteLabel.unsafeRunSync()
+response.result match {
+  case Left(e) => println(s"Something went wrong: ${e.getMessage}")
+  case Right(r) => println(r)
+}
+```
+
+The `result` on the right is `Unit`.
+
+See [the API doc](https://developer.github.com/v3/issues/labels/#delete-a-label) for full reference.
 
 ### List labels
 

--- a/microsite/docs/issue.md
+++ b/microsite/docs/issue.md
@@ -44,6 +44,7 @@ import java.util.concurrent._
 
 import cats.effect.{Blocker, ContextShift, IO}
 import github4s.Github
+import github4s.domain.Label
 import org.http4s.client.{Client, JavaNetClientBuilder}
 
 import scala.concurrent.ExecutionContext.global


### PR DESCRIPTION
Hi, 

During using of this library I found missed API's: 
- [createLabel](https://developer.github.com/v3/issues/labels/#create-a-label), 
- [updateLabel](https://developer.github.com/v3/issues/labels/#update-a-label)
- [deleteLabel](https://developer.github.com/v3/issues/labels/#delete-a-label)

This endpoint's need to create a custom label for repository, for example, specify color.

For this reason I must to change domain of Label, this changes a breaking, so maybe it's reasonable to create other model like  `LabelData`.