### PR TITLE
Repository model enriched: Archived status available now

### DIFF
--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -119,6 +119,7 @@ object Decoders {
         priv              <- c.downField("private").as[Boolean]
         description       <- c.downField("description").as[Option[String]]
         fork              <- c.downField("fork").as[Boolean]
+        archived          <- c.downField("archived").as[Boolean]
         created_at        <- c.downField("created_at").as[String]
         updated_at        <- c.downField("updated_at").as[String]
         pushed_at         <- c.downField("pushed_at").as[String]
@@ -153,6 +154,7 @@ object Decoders {
         `private` = priv,
         description = description,
         fork = fork,
+        archived = archived,
         created_at = created_at,
         updated_at = updated_at,
         pushed_at = pushed_at,

--- a/github4s/src/main/scala/github4s/domain/Repository.scala
+++ b/github4s/src/main/scala/github4s/domain/Repository.scala
@@ -23,6 +23,7 @@ final case class Repository(
     owner: User,
     `private`: Boolean,
     fork: Boolean,
+    archived: Boolean,
     urls: RepoUrls,
     created_at: String,
     updated_at: String,

--- a/github4s/src/test/scala/github4s/utils/FakeResponses.scala
+++ b/github4s/src/test/scala/github4s/utils/FakeResponses.scala
@@ -83,6 +83,7 @@ trait FakeResponses {
       |  "html_url": "https://github.com/47degrees/github4s",
       |  "description": "A GitHub API wrapper written in Scala",
       |  "fork": false,
+      |  "archived": false,
       |  "url": "https://api.github.com/repos/47degrees/github4s",
       |  "forks_url": "https://api.github.com/repos/47degrees/github4s/forks",
       |  "keys_url": "https://api.github.com/repos/47degrees/github4s/keys{/key_id}",

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -374,6 +374,7 @@ trait TestData {
     user,
     false,
     false,
+    false,
     RepoUrls(
       s"https://api.github.com/repos/$validRepoOwner/$validRepoName",
       s"https://github.com/$validRepoOwner/$validRepoName",


### PR DESCRIPTION
We're using this library for making tech.map of our organisation - so we need filter out archived repositories. 

To make it possible I did small changes - I've enriched repository model to support "archived" status.  

If PR need some improvements - please write me - I'll do it. 