### PR TITLE
Add parent/source fields to Repository

### DIFF
--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -108,7 +108,7 @@ object Decoders {
     }
   }
 
-  implicit val decodeRepository: Decoder[Repository] = {
+  implicit val decodeRepositoryBase: Decoder[RepositoryBase] = {
 
     Decoder.instance { c =>
       for {
@@ -146,7 +146,7 @@ object Decoders {
         clone_url         <- c.downField("clone_url").as[String]
         svn_url           <- c.downField("svn_url").as[String]
         repoUrls          <- readRepoUrls(c)
-      } yield Repository(
+      } yield RepositoryBase(
         id = id,
         name = name,
         full_name = full_name,
@@ -188,6 +188,12 @@ object Decoders {
       )
     }
   }
+
+  implicit val decodeRepository: Decoder[Repository] = for {
+    base   <- decodeRepositoryBase
+    parent <- Decoder[Option[RepositoryBase]].at("parent")
+    source <- Decoder[Option[RepositoryBase]].at("source")
+  } yield Repository.fromBaseRepos(base, parent, source)
 
   implicit val decodePRStatus: Decoder[PullRequestReviewState] =
     Decoder.decodeString.map {

--- a/github4s/src/main/scala/github4s/domain/Repository.scala
+++ b/github4s/src/main/scala/github4s/domain/Repository.scala
@@ -16,7 +16,8 @@
 
 package github4s.domain
 
-final case class Repository(
+/** A `Repository` but without any recursive definitions (`parent` and `source`) */
+final case class RepositoryBase(
     id: Long,
     name: String,
     full_name: String,
@@ -35,6 +36,57 @@ final case class Repository(
     organization: Option[User] = None,
     permissions: Option[RepoPermissions] = None
 )
+
+final case class Repository(
+    id: Long,
+    name: String,
+    full_name: String,
+    owner: User,
+    `private`: Boolean,
+    fork: Boolean,
+    archived: Boolean,
+    urls: RepoUrls,
+    created_at: String,
+    updated_at: String,
+    pushed_at: String,
+    status: RepoStatus,
+    description: Option[String] = None,
+    homepage: Option[String] = None,
+    language: Option[String] = None,
+    organization: Option[User] = None,
+    parent: Option[RepositoryBase] = None,
+    permissions: Option[RepoPermissions] = None,
+    source: Option[RepositoryBase] = None
+)
+
+object Repository {
+  def fromBaseRepos(
+      b: RepositoryBase,
+      parent: Option[RepositoryBase],
+      source: Option[RepositoryBase]
+  ) =
+    Repository(
+      b.id,
+      b.name,
+      b.full_name,
+      b.owner,
+      b.`private`,
+      b.fork,
+      b.archived,
+      b.urls,
+      b.created_at,
+      b.updated_at,
+      b.pushed_at,
+      b.status,
+      b.description,
+      b.homepage,
+      b.language,
+      b.organization,
+      parent,
+      b.permissions,
+      source
+    )
+}
 
 final case class RepoPermissions(
     admin: Boolean,


### PR DESCRIPTION
Resolves #603 

Adds the `parent` and `source` fields to `Repository` which previously did not have them before. As the types are recursive and we define our own decoders, I decided to define these fields as a new type `RepositoryBase` which is exactly the same, only not recursive. The docs do not seem to indicate multiple levels of recursion so this is likely the more correct approach as well.