### PR TITLE
Remove mocking from tests; use http4s directly

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,9 +1,8 @@
 # Cats jvmopts see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
--Dfile.encoding=UTF8
 -Xms2G
 -Xmx6G
 -Xss64m
--XX:MaxMetaspaceSize=512M
+-XX:MaxMetaspaceSize=1024M
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit

--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -18,20 +18,27 @@ package github4s
 
 import github4s.domain._
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 
 object Encoders {
 
-  implicit val encodeTreeData: Encoder[TreeData] = Encoder.instance {
-    case d: TreeDataSha  => d.asJson
-    case d: TreeDataBlob => d.asJson
+  implicit val encodeTreeData: Encoder[TreeData] = {
+    val sha  = deriveEncoder[TreeDataSha]
+    val blob = deriveEncoder[TreeDataBlob]
+    Encoder.instance {
+      case d: TreeDataSha  => sha(d)
+      case d: TreeDataBlob => blob(d)
+    }
   }
 
-  implicit val encodeNewPullRequest: Encoder[CreatePullRequest] = Encoder.instance {
-    case d: CreatePullRequestData  => d.asJson
-    case d: CreatePullRequestIssue => d.asJson
+  implicit val encodeNewPullRequest: Encoder[CreatePullRequest] = {
+    val data  = deriveEncoder[CreatePullRequestData]
+    val issue = deriveEncoder[CreatePullRequestIssue]
+    Encoder.instance {
+      case d: CreatePullRequestData  => data(d)
+      case d: CreatePullRequestIssue => issue(d)
+    }
   }
 
   implicit val encodePrrStatus: Encoder[PullRequestReviewState] =
@@ -46,7 +53,111 @@ object Encoders {
     )
   }
 
-  implicit val encoderCommiter: Encoder[Committer] = deriveEncoder[Committer]
+  implicit val encoderCommit: Encoder[Commit] = Encoder.instance { c =>
+    Json.obj(
+      "sha"      -> c.sha.asJson,
+      "html_url" -> c.url.asJson,
+      "author" -> Json.obj(
+        "avatar_url" -> c.avatar_url.asJson,
+        "html_url"   -> c.author_url.asJson,
+        "login"      -> c.login.asJson
+      ),
+      "commit" -> Json.obj(
+        "message" -> c.message.asJson,
+        "author"  -> Json.obj("date" -> c.date.asJson)
+      )
+    )
+  }
+
+  implicit val encoderReviewersResponse: Encoder[ReviewersResponse] =
+    deriveEncoder[ReviewersResponse]
+  implicit val encoderSearchIssuesResult: Encoder[SearchIssuesResult] =
+    deriveEncoder[SearchIssuesResult]
+  implicit val encoderSearchReposResult: Encoder[SearchReposResult] =
+    deriveEncoder[SearchReposResult]
+  implicit val encoderStatusRepository: Encoder[StatusRepository] = {
+    val base = deriveEncoder[StatusRepository]
+    base.mapJsonObject { j =>
+      val urls    = j("urls").flatMap(_.asObject)
+      val updated = j.remove("urls")
+      urls.map(updated.deepMerge).getOrElse(updated)
+    }
+
+  }
+  implicit val encoderStatus: Encoder[Status]         = deriveEncoder[Status]
+  implicit val encoderTreeResult: Encoder[TreeResult] = deriveEncoder[TreeResult]
+  implicit val encoderUserRepoPermission: Encoder[UserRepoPermission] =
+    deriveEncoder[UserRepoPermission]
+  implicit val encoderWriteFileResponse: Encoder[WriteFileResponse] =
+    deriveEncoder[WriteFileResponse]
+  implicit val encoderWriteResponseCommit: Encoder[WriteResponseCommit] =
+    deriveEncoder[WriteResponseCommit]
+  implicit val encoderSubscription: Encoder[Subscription]       = deriveEncoder[Subscription]
+  implicit val encoderTag: Encoder[Tag]                         = deriveEncoder[Tag]
+  implicit val encoderTeam: Encoder[Team]                       = deriveEncoder[Team]
+  implicit val encoderTreeDataResult: Encoder[TreeDataResult]   = deriveEncoder[TreeDataResult]
+  implicit val encoderOAuthToken: Encoder[OAuthToken]           = deriveEncoder[OAuthToken]
+  implicit val encoderProject: Encoder[Project]                 = deriveEncoder[Project]
+  implicit val encoderPullRequestBase: Encoder[PullRequestBase] = deriveEncoder[PullRequestBase]
+  implicit val encoderPullRequestFile: Encoder[PullRequestFile] = deriveEncoder[PullRequestFile]
+  implicit val encoderBlobContent: Encoder[BlobContent]         = deriveEncoder[BlobContent]
+  implicit val encoderBranchCommit: Encoder[BranchCommit]       = deriveEncoder[BranchCommit]
+  implicit val encoderBranch: Encoder[Branch]                   = deriveEncoder[Branch]
+  implicit val encoderCard: Encoder[Card]                       = deriveEncoder[Card]
+  implicit val encoderColumn: Encoder[Column]                   = deriveEncoder[Column]
+  implicit val encoderCombinedStatus: Encoder[CombinedStatus]   = deriveEncoder[CombinedStatus]
+  implicit val encoderCommiter: Encoder[Committer]              = deriveEncoder[Committer]
+  implicit val encoderContent: Encoder[Content]                 = deriveEncoder[Content]
+  implicit val encoderCreator: Encoder[Creator]                 = deriveEncoder[Creator]
+  implicit val encoderPullRequestReview: Encoder[PullRequestReview] =
+    deriveEncoder[PullRequestReview]
+  implicit val encoderRefAuthor: Encoder[RefAuthor]             = deriveEncoder[RefAuthor]
+  implicit val encoderRefCommit: Encoder[RefCommit]             = deriveEncoder[RefCommit]
+  implicit val encoderRefInfo: Encoder[RefInfo]                 = deriveEncoder[RefInfo]
+  implicit val encoderRefObject: Encoder[RefObject]             = deriveEncoder[RefObject]
+  implicit val encoderRef: Encoder[Ref]                         = deriveEncoder[Ref]
+  implicit val encoderRelease: Encoder[Release]                 = deriveEncoder[Release]
+  implicit val encoderRepoPermissions: Encoder[RepoPermissions] = deriveEncoder[RepoPermissions]
+  implicit val encoderRepositoryBase: Encoder[RepositoryBase] = Encoder.instance[RepositoryBase] {
+    rb =>
+      Json.obj(
+        "id"                -> rb.id.asJson,
+        "name"              -> rb.name.asJson,
+        "full_name"         -> rb.full_name.asJson,
+        "owner"             -> rb.owner.asJson,
+        "private"           -> rb.`private`.asJson,
+        "description"       -> rb.description.asJson,
+        "fork"              -> rb.fork.asJson,
+        "archived"          -> rb.archived.asJson,
+        "created_at"        -> rb.created_at.asJson,
+        "updated_at"        -> rb.updated_at.asJson,
+        "pushed_at"         -> rb.pushed_at.asJson,
+        "homepage"          -> rb.homepage.asJson,
+        "language"          -> rb.language.asJson,
+        "organization"      -> rb.organization.asJson,
+        "size"              -> rb.status.size.asJson,
+        "stargazers_count"  -> rb.status.stargazers_count.asJson,
+        "watchers_count"    -> rb.status.watchers_count.asJson,
+        "forks_count"       -> rb.status.forks_count.asJson,
+        "open_issues_count" -> rb.status.open_issues_count.asJson,
+        "open_issues"       -> rb.status.open_issues.asJson,
+        "watchers"          -> rb.status.watchers.asJson,
+        "network_count"     -> rb.status.network_count.asJson,
+        "subscribers_count" -> rb.status.subscribers_count.asJson,
+        "has_issues"        -> rb.status.has_issues.asJson,
+        "has_downloads"     -> rb.status.has_downloads.asJson,
+        "has_wiki"          -> rb.status.has_wiki.asJson,
+        "has_pages"         -> rb.status.has_pages.asJson,
+        "url"               -> rb.urls.url.asJson,
+        "html_url"          -> rb.urls.html_url.asJson,
+        "git_url"           -> rb.urls.git_url.asJson,
+        "ssh_url"           -> rb.urls.ssh_url.asJson,
+        "clone_url"         -> rb.urls.clone_url.asJson,
+        "svn_url"           -> rb.urls.svn_url.asJson,
+        "permissions"       -> rb.permissions.asJson
+      )
+  }
+  implicit val encoderPullRequest: Encoder[PullRequest] = deriveEncoder[PullRequest]
   implicit val encoderDeleteFileRequest: Encoder[DeleteFileRequest] =
     deriveEncoder[DeleteFileRequest]
   implicit val encoderWriteFileContentRequest: Encoder[WriteFileRequest] =
@@ -71,8 +182,59 @@ object Encoders {
     deriveEncoder[NewReleaseRequest]
   implicit val encoderNewStatusRequest: Encoder[NewStatusRequest] = deriveEncoder[NewStatusRequest]
   implicit val encoderMilestoneData: Encoder[MilestoneData]       = deriveEncoder[MilestoneData]
+  implicit val encoderCreateReviewComment: Encoder[CreateReviewComment] =
+    deriveEncoder[CreateReviewComment]
   implicit val encodeNewPullRequestReview: Encoder[CreatePRReviewRequest] =
     deriveEncoder[CreatePRReviewRequest]
   implicit val encodeRequiestedReviewers: Encoder[ReviewersRequest] =
     deriveEncoder[ReviewersRequest]
+  implicit val encodeStargazer: Encoder[Stargazer] =
+    Encoder.instance[Stargazer] { s =>
+      val user = Encoder[User].apply(s.user)
+      s.starred_at match {
+        case Some(value) =>
+          Json.obj("starred_at" -> value.asJson, "user" -> user)
+        case None => user
+      }
+    }
+
+  implicit val encodeRepository: Encoder[Repository] = Encoder.instance[Repository] { r =>
+    val base = RepositoryBase(
+      id = r.id,
+      name = r.name,
+      full_name = r.full_name,
+      owner = r.owner,
+      `private` = r.`private`,
+      fork = r.fork,
+      archived = r.archived,
+      urls = r.urls,
+      created_at = r.created_at,
+      updated_at = r.updated_at,
+      pushed_at = r.pushed_at,
+      status = r.status,
+      description = r.description,
+      homepage = r.homepage,
+      language = r.language,
+      organization = r.organization,
+      permissions = r.permissions
+    )
+    base.asJson deepMerge
+      Json.obj("parent" -> r.parent.asJson, "source" -> r.source.asJson)
+  }
+  implicit val encodeStarredRepository: Encoder[StarredRepository] =
+    Encoder.instance[StarredRepository] { sr =>
+      val repo = Encoder[Repository].apply(sr.repo)
+      sr.starred_at match {
+        case Some(value) =>
+          Json.obj("starred_at" -> value.asJson, "repo" -> repo)
+        case None => repo
+      }
+    }
+  implicit val encoderIssue: Encoder[Issue]                       = deriveEncoder[Issue]
+  implicit val encoderIssuePullRequest: Encoder[IssuePullRequest] = deriveEncoder[IssuePullRequest]
+  implicit val encoderGistFile: Encoder[GistFile]                 = deriveEncoder[GistFile]
+  implicit val encodeGist: Encoder[Gist]                          = deriveEncoder[Gist]
+  implicit val encoderUser: Encoder[User]                         = deriveEncoder[User]
+  implicit val encoderComment: Encoder[Comment]                   = deriveEncoder[Comment]
+  implicit val encoderMilestone: Encoder[Milestone]               = deriveEncoder[Milestone]
 }

--- a/github4s/src/test/scala-2/github4s/ArbitraryDerivation.scala
+++ b/github4s/src/test/scala-2/github4s/ArbitraryDerivation.scala
@@ -1,0 +1,14 @@
+package github4s
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.derive.MkArbitrary
+
+// Note: This is in scala-2 source dir because shapeless isn't available for scala3. The scala3 derivation method would use another mechanism
+object ArbitraryDerivation { self =>
+
+  def deriveArb[A](implicit mkArbitrary: MkArbitrary[A]): Arbitrary[A] = mkArbitrary.arbitrary
+
+  object auto {
+    implicit def deriveArb[A: MkArbitrary]: Arbitrary[A] = self.deriveArb[A]
+  }
+}

--- a/github4s/src/test/scala-2/github4s/unit/EncoderDecoderSpec.scala
+++ b/github4s/src/test/scala-2/github4s/unit/EncoderDecoderSpec.scala
@@ -1,0 +1,156 @@
+package github4s.unit
+
+import cats.syntax.all._
+import com.eed3si9n.expecty.Expecty
+import github4s.ArbitraryDerivation
+import github4s.Decoders._
+import github4s.Encoders._
+import github4s.domain._
+import io.circe.{Decoder, Encoder, Printer}
+import org.scalacheck.fortyseven.GenInstances._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalactic.source.Position
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.reflect.ClassTag
+
+class EncoderDecoderSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
+  import github4s.ArbitraryDerivation.auto._
+
+  private def checkRoundtrip[A](implicit
+      enc: Encoder[A],
+      dec: Decoder[A],
+      arb: Arbitrary[A],
+      pos: Position
+  ): Assertion = {
+    forAll { (value: A) =>
+      // Use Expecty asserts here because manually figuring out the diff between two large, possibly nested, case classes is not a fun time
+      val encoded   = enc(value)
+      val attempted = dec.decodeJson(encoded)
+      val decoded   = attempted.fold(e => fail(s"decode failure: $e\nEncoded:\n$encoded"), identity)
+      withClue(encoded.printWith(Printer.spaces2SortKeys)) {
+        try Expecty.assert(decoded == value)
+        catch {
+          // withClue doesn't work with AssertionError - It shows up as a test in error rather than a failure
+          case e: AssertionError => fail(e)
+        }
+      }
+      succeed // expecty returns Unit, forAll wants an Assertion
+    }
+  }
+
+  private def test[A: Encoder: Decoder: Arbitrary](implicit
+      tag: ClassTag[A],
+      pos: Position
+  ): Unit = {
+    val name = tag.runtimeClass.getSimpleName
+    registerTest(s"Encode/Decode: $name")(checkRoundtrip[A])
+  }
+
+  /** Custom instance since `Team` is recursive - it can't be derived */
+  implicit def arbTeam: Arbitrary[Team] = Arbitrary {
+    import Arbitrary.{arbitrary => arb}
+    (
+      arb[Long],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[String],
+      arb[Option[String]],
+      arb[Option[Team]]
+    ).mapN(Team.apply)
+  }
+
+  implicit val arbStatusRepository: Arbitrary[StatusRepository] = {
+    val base = ArbitraryDerivation.deriveArb[StatusRepository].arbitrary
+    val genUrls = Gen.mapOf(
+      (Gen.oneOf(RepoUrlKeys.allFields), Gen.asciiPrintableStr).tupled
+    )
+    Arbitrary {
+      (base, genUrls).mapN { (sr, urls) =>
+        sr.copy(urls = urls)
+      }
+    }
+  }
+
+  test[BlobContent]
+  test[BranchCommit]
+  test[Branch]
+  test[Card]
+  test[Column]
+  test[CombinedStatus]
+  test[CommentData]
+  test[Comment]
+  test[Commit]
+  test[Committer]
+  test[Content]
+  test[CreatePRReviewRequest]
+  test[CreatePullRequest]
+  test[CreateReferenceRequest]
+  test[Creator]
+  test[DeleteFileRequest]
+  test[EditGistFile]
+  test[EditGistRequest]
+  test[EditIssueRequest]
+  test[GistFile]
+  test[Gist]
+  test[IssuePullRequest]
+  test[Issue]
+  test[Label]
+  test[MilestoneData]
+  test[Milestone]
+  test[NewBlobRequest]
+  test[NewCommitRequest]
+  test[NewGistRequest]
+  test[NewIssueRequest]
+  test[NewReleaseRequest]
+  test[NewStatusRequest]
+  test[NewTagRequest]
+  test[NewTreeRequest]
+  test[OAuthToken]
+  test[Project]
+  test[PullRequestBase]
+  test[PullRequestFile]
+  test[PullRequestReviewEvent]
+  test[PullRequestReviewState]
+  test[PullRequestReview]
+  test[PullRequest]
+  test[RefAuthor]
+  test[RefCommit]
+  test[RefInfo]
+  test[RefObject]
+  test[Ref]
+  test[Release]
+  test[RepoPermissions]
+  test[RepositoryBase]
+  test[Repository]
+  test[ReviewersRequest]
+  test[ReviewersResponse]
+  test[SearchIssuesResult]
+  test[SearchReposResult]
+  test[Stargazer]
+  test[StarredRepository]
+  test[StatusRepository]
+  test[Status]
+  test[SubscriptionRequest]
+  test[Subscription]
+  test[Tag]
+  test[Team]
+  test[TreeDataResult]
+  test[TreeData]
+  test[TreeResult]
+  test[UpdateReferenceRequest]
+  test[UserRepoPermission]
+  test[User]
+  test[WriteFileRequest]
+  test[WriteFileResponse]
+  test[WriteResponseCommit]
+
+}

--- a/github4s/src/test/scala-3/github4s/ArbitraryDerivation.scala
+++ b/github4s/src/test/scala-3/github4s/ArbitraryDerivation.scala
@@ -1,0 +1,49 @@
+package github4s
+
+import org.scalacheck.{Arbitrary, Gen}
+import shapeless3.deriving.*
+import scala.compiletime.*
+import scala.collection.immutable.ArraySeq
+
+object ArbitraryDerivation { self =>
+  object semiauto:
+    extension (A: Arbitrary.type)
+      inline def derived[A]: Arbitrary[A] =
+        import auto.given
+        summonInline[Arbitrary[A]]
+
+  inline def deriveArb[A](using g: K0.Generic[A]): Arbitrary[A] =
+    import semiauto._
+    Arbitrary.derived[A]
+
+  object auto {
+    given deriveArb[A](using gen: DerivedGen[A]): Arbitrary[A] = gen.arb
+  }
+
+}
+
+// Credit to Georgi Krastev on the typelevel discord;
+// https://scastie.scala-lang.org/b8CXWfmXQUClqXplyA6TJg
+opaque type DerivedGen[A] = Gen[A]
+object DerivedGen extends DerivedGenInstances:
+  given [A]: Conversion[Gen[A], DerivedGen[A]] = identity
+  extension [A](gen: DerivedGen[A]) def arb: Arbitrary[A] = Arbitrary(gen)
+
+  private final class ArrayProduct(elems: Array[Any]) extends Product:
+    def canEqual(that: Any): Boolean = true
+    def productElement(n: Int): Any = elems(n)
+    def productArity: Int = elems.length
+    override def productIterator: Iterator[Any] = elems.iterator
+
+  def product[A](arbs: Seq[Arbitrary[_]])(using gen: K0.ProductGeneric[A]): DerivedGen[A] =
+    Gen.sequence[Array[Any], Any](arbs.map(_.arbitrary)).map(arr => gen.fromProduct(ArrayProduct(arr)).asInstanceOf[A])
+
+  def coproduct[A](arbs: => IndexedSeq[Arbitrary[_ <: A]]): DerivedGen[A] =
+    Gen.lzy(if arbs.isEmpty then Gen.fail else Gen.choose(0, arbs.length - 1).flatMap(arbs(_).arbitrary))
+
+sealed abstract class DerivedGenInstances:
+  inline def summonAllArb[A, U](using gen: K0.Generic[A]): IndexedSeq[Arbitrary[_ <: U]] =
+    ArraySeq.unsafeWrapArray(summonAsArray[K0.LiftP[Arbitrary, gen.MirroredElemTypes]]).asInstanceOf
+
+  inline given derived[A](using gen: K0.Generic[A]): DerivedGen[A] =
+    gen.derive(DerivedGen.product(summonAllArb[A, Any]), DerivedGen.coproduct(summonAllArb[A, A]))

--- a/github4s/src/test/scala/github4s/IOAssertions.scala
+++ b/github4s/src/test/scala/github4s/IOAssertions.scala
@@ -1,0 +1,78 @@
+package github4s
+
+import cats.Eq
+import cats.effect.{ContextShift, IO, Timer}
+import org.scalactic.Prettifier
+import org.scalactic.source.Position
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.{Assertion, AsyncTestSuite}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+/* Copied from: https://gist.github.com/Daenyth/67575575b5c1acc1d6ea100aae05b3a9
+   Under MIT license
+ */
+trait IOAssertions { self: AsyncTestSuite with org.scalatest.Assertions =>
+
+  // It's "extremely unsafe" because it's an implicit conversion that takes a pure value
+  // and silently converts it to a side effecting value that begins running on a thread immediately.
+  implicit def extremelyUnsafeIOAssertionToFuture(ioa: IO[Assertion])(implicit
+      pos: Position
+  ): Future[Assertion] = {
+    val _ = pos // unused here; exists for override to use
+    ioa.unsafeToFuture()
+  }
+
+  implicit protected class IOAssertionOps[A](val io: IO[A])(implicit
+      pos: Position
+  ) {
+
+    /**
+     * Same as shouldNotFail, but preferable in cases where explicit type signatures are not used,
+     * as `shouldNotFail` will discard any result, and this method will only compile where the
+     * author intends `io` to be made from assertions.
+     *
+     * @example
+     *   {{{ List(1,2,3,4,5,6).traverse { n => databaseCheck(n).map { result => result shouldEqual
+     *   GoodValue } }.flattenAssertion }}}
+     */
+    def flattenAssertion(implicit ev: A <:< Seq[Assertion]): IO[Assertion] = {
+      val _ = ev // "unused implicit" warning
+      io.shouldNotFail
+    }
+
+    def shouldResultIn(
+        expected: A
+    )(implicit eq: Eq[A], prettifier: Prettifier): IO[Assertion] =
+      io.flatMap { actual =>
+        IO(assert(eq.eqv(expected, actual)))
+      }
+
+    def shouldNotFail: IO[Assertion] = io.attempt.flatMap {
+      case Left(failed: TestFailedException) =>
+        IO.raiseError(failed)
+      case Left(err) =>
+        IO(fail(s"IO Failed with ${err.getMessage}", err))
+      case Right(_) =>
+        IO.pure(succeed)
+
+    }
+
+    def shouldTerminate(
+        within: FiniteDuration = 5.seconds
+    )(implicit timer: Timer[IO], CS: ContextShift[IO]): IO[Assertion] =
+      io.shouldNotFail.timeoutTo(within, IO(fail(s"IO didn't terminate within $within")))
+
+    /**
+     * Equivalent to [[org.scalatest.Assertions.assertThrows]] for [[cats.effect.IO]]
+     */
+    def shouldFailWith[T <: AnyRef](implicit
+        classTag: ClassTag[T]
+    ): IO[Assertion] =
+      io.attempt.flatMap { attempt =>
+        IO(assertThrows[T](attempt.toTry.get))
+      }
+  }
+}

--- a/github4s/src/test/scala/github4s/integration/IssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/IssuesSpec.scala
@@ -66,6 +66,24 @@ trait IssuesSpec extends BaseIntegrationSpec {
     response.statusCode shouldBe okStatusCode
   }
 
+  it should "not regress github #569" taggedAs Integration in {
+    clientResource
+      .use { client =>
+        Github[IO](client, accessToken).issues.searchIssues(
+          "",
+          List(
+            OwnerParamInRepository("47degrees/github4s"),
+            IssueTypePullRequest,
+            LabelParam("bug"),
+            IssueStateOpen
+          )
+        )
+      }
+      .map { response =>
+        response.statusCode shouldBe okStatusCode
+      }
+  }
+
   it should "return an empty result for a non existent query string" taggedAs Integration in {
     val response = clientResource
       .use { client =>

--- a/github4s/src/test/scala/github4s/integration/PullRequestsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/PullRequestsSpec.scala
@@ -312,7 +312,7 @@ trait PullRequestsSpec extends BaseIntegrationSpec {
 
     testIsRight[PullRequest](
       addReviewersResponse,
-      r => r.body shouldBe validCreatePRReviewRequest.body
+      r => r.body shouldBe Some(validCreatePRReviewRequest.body)
     )
     addReviewersResponse.statusCode shouldBe okStatusCode
 
@@ -352,7 +352,7 @@ trait PullRequestsSpec extends BaseIntegrationSpec {
 
     testIsRight[PullRequest](
       addReviewersResponse,
-      r => r.body shouldBe validCreatePRReviewRequest.body
+      r => r.body shouldBe Some(validCreatePRReviewRequest.body)
     )
     removeReviewersResponse.statusCode shouldBe okStatusCode
   }

--- a/github4s/src/test/scala/github4s/unit/ActivitiesSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/ActivitiesSpec.scala
@@ -17,60 +17,57 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
-import github4s.interpreters.ActivitiesInterpreter
+import github4s.Decoders._
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
+import github4s.interpreters.ActivitiesInterpreter
 import github4s.utils.BaseSpec
 
 class ActivitiesSpec extends BaseSpec {
 
   "Activity.setThreadSub" should "call to httpClient.put with the right parameters" in {
 
-    val response: IO[GHResponse[Subscription]] =
-      IO(GHResponse(subscription.asRight, okStatusCode, Map.empty))
-
     val request = SubscriptionRequest(true, false)
 
-    implicit val httpClientMock = httpClientMockPut[SubscriptionRequest, Subscription](
-      url = s"notifications/threads/$validThreadId/subscription",
-      req = request,
-      response = response
-    )
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPut[SubscriptionRequest, Subscription](
+        url = s"notifications/threads/$validThreadId/subscription",
+        req = request,
+        response = IO.pure(subscription)
+      )
 
     val activities = new ActivitiesInterpreter[IO]
 
-    activities.setThreadSub(validThreadId, true, false, headerUserAgent)
+    activities.setThreadSub(validThreadId, true, false, headerUserAgent).shouldNotFail
   }
 
   "Activity.listStargazers" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[Stargazer]]] =
-      IO(GHResponse(List(stargazer).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[Stargazer]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Stargazer]](
       url = s"repos/$validRepoOwner/$validRepoName/stargazers",
-      response = response
+      response = IO.pure(List(stargazer))
     )
 
     val activities = new ActivitiesInterpreter[IO]
 
-    activities.listStargazers(validRepoOwner, validRepoName, false, None, headerUserAgent)
+    activities
+      .listStargazers(validRepoOwner, validRepoName, false, None, headerUserAgent)
+      .shouldNotFail
   }
 
   "Activity.listStarredRepositories" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[StarredRepository]]] =
-      IO(GHResponse(List(starredRepository).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[StarredRepository]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[StarredRepository]](
       url = s"users/$validUsername/starred",
-      response = response
+      response = IO.pure(List(starredRepository))
     )
 
     val activities = new ActivitiesInterpreter[IO]
 
-    activities.listStarredRepositories(validUsername, false, None, None, None, headerUserAgent)
+    activities
+      .listStarredRepositories(validUsername, false, None, None, None, headerUserAgent)
+      .shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/AuthSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/AuthSpec.scala
@@ -17,33 +17,32 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
-import github4s.utils.BaseSpec
 import github4s.domain._
+import github4s.http.HttpClient
 import github4s.interpreters.AuthInterpreter
+import github4s.utils.BaseSpec
+import github4s.Encoders._
 
 class AuthSpec extends BaseSpec {
 
   "Auth.getAccessToken" should "call to httpClient.postOAuth with the right parameters" in {
 
-    val response: IO[GHResponse[OAuthToken]] =
-      IO(GHResponse(oAuthToken.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockPostOAuth[OAuthToken](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPostOAuth[OAuthToken](
       url = dummyConfig.accessTokenUrl,
-      response = response
+      response = IO.pure(oAuthToken)
     )
 
     val auth = new AuthInterpreter[IO]
 
-    auth.getAccessToken(
-      validClientId,
-      invalidClientSecret,
-      validCode,
-      validRedirectUri,
-      validAuthState,
-      headerUserAgent
-    )
+    auth
+      .getAccessToken(
+        validClientId,
+        invalidClientSecret,
+        validCode,
+        validRedirectUri,
+        validAuthState,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 }

--- a/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/IssuesSpec.scala
@@ -16,92 +16,85 @@
 
 package github4s.unit
 
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
+import github4s.Encoders._
+import github4s.Decoders._
 import github4s.domain._
+import github4s.http.HttpClient
 import github4s.interpreters.IssuesInterpreter
 import github4s.utils.BaseSpec
+import org.http4s
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 class IssuesSpec extends BaseSpec {
 
   "Issues.listIssues" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Issue]]] =
-      IO(GHResponse(List(issue).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Issue]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Issue]](
       url = s"repos/$validRepoOwner/$validRepoName/issues",
-      response = response
+      response = IO.pure(List(issue))
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.listIssues(validRepoOwner, validRepoName, None, headerUserAgent)
+    issues.listIssues(validRepoOwner, validRepoName, None, headerUserAgent).shouldNotFail
 
   }
 
   "Issues.getIssue" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[Issue]] =
-      IO(GHResponse(issue.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[Issue](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[Issue](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber",
-      response = response
+      response = IO.pure(issue)
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.getIssue(validRepoOwner, validRepoName, validIssueNumber, headerUserAgent)
-
+    issues.getIssue(validRepoOwner, validRepoName, validIssueNumber, headerUserAgent).shouldNotFail
   }
 
   "Issues.searchIssues" should "call htppClient.get with the right parameters" in {
-    val response: IO[GHResponse[SearchIssuesResult]] =
-      IO(GHResponse(searchIssuesResult.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[SearchIssuesResult](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[SearchIssuesResult](
       url = s"search/issues",
-      response = response,
+      response = IO.pure(searchIssuesResult),
       params = Map("q" -> s"+${validSearchParams.map(_.value).mkString("+")}")
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.searchIssues("", validSearchParams, None, headerUserAgent)
+    issues.searchIssues("", validSearchParams, None, headerUserAgent).shouldNotFail
   }
 
   "Issues.createIssue" should "call httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[Issue]] =
-      IO(GHResponse(issue.asRight, createdStatusCode, Map.empty))
 
     val request = NewIssueRequest(validIssueTitle, validIssueBody, List.empty, List.empty)
 
-    implicit val httpClientMock = httpClientMockPost[NewIssueRequest, Issue](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[NewIssueRequest, Issue](
       url = s"repos/$validRepoOwner/$validRepoName/issues",
       req = request,
-      response = response
+      response = IO.pure(issue)
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.createIssue(
-      validRepoOwner,
-      validRepoName,
-      validIssueTitle,
-      validIssueBody,
-      None,
-      List.empty,
-      List.empty,
-      headerUserAgent
-    )
-
+    issues
+      .createIssue(
+        validRepoOwner,
+        validRepoName,
+        validIssueTitle,
+        validIssueBody,
+        None,
+        List.empty,
+        List.empty,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.editIssue" should "call httpClient.patch with the right parameters" in {
-    val response: IO[GHResponse[Issue]] = IO(GHResponse(issue.asRight, okStatusCode, Map.empty))
 
     val request = EditIssueRequest(
       validIssueState,
@@ -111,270 +104,267 @@ class IssuesSpec extends BaseSpec {
       List.empty
     )
 
-    implicit val httpClientMock = httpClientMockPatch[EditIssueRequest, Issue](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPatch[EditIssueRequest, Issue](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber",
       req = request,
-      response = response
+      response = IO.pure(issue)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.editIssue(
-      validRepoOwner,
-      validRepoName,
-      validIssueNumber,
-      validIssueState,
-      validIssueTitle,
-      validIssueBody,
-      None,
-      List.empty,
-      List.empty,
-      headerUserAgent
-    )
+    issues
+      .editIssue(
+        validRepoOwner,
+        validRepoName,
+        validIssueNumber,
+        validIssueState,
+        validIssueTitle,
+        validIssueBody,
+        None,
+        List.empty,
+        List.empty,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.ListComments" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Comment]]] =
-      IO(GHResponse(List(comment).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Comment]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Comment]](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber/comments",
-      response = response
+      response = IO.pure(List(comment))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.listComments(validRepoOwner, validRepoName, validIssueNumber, None, headerUserAgent)
+    issues
+      .listComments(validRepoOwner, validRepoName, validIssueNumber, None, headerUserAgent)
+      .shouldNotFail
   }
 
   "Issue.CreateComment" should "call to httpClient.post with the right parameters" in {
 
-    val response: IO[GHResponse[Comment]] =
-      IO(GHResponse(comment.asRight, createdStatusCode, Map.empty))
-
     val request = CommentData(validCommentBody)
 
-    implicit val httpClientMock = httpClientMockPost[CommentData, Comment](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[CommentData, Comment](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber/comments",
       req = request,
-      response = response
+      response = IO.pure(comment)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.createComment(
-      validRepoOwner,
-      validRepoName,
-      validIssueNumber,
-      validCommentBody,
-      headerUserAgent
-    )
+    issues
+      .createComment(
+        validRepoOwner,
+        validRepoName,
+        validIssueNumber,
+        validCommentBody,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issue.EditComment" should "call to httpClient.patch with the right parameters" in {
 
-    val response: IO[GHResponse[Comment]] =
-      IO(GHResponse(comment.asRight, okStatusCode, Map.empty))
-
     val request = CommentData(validCommentBody)
 
-    implicit val httpClientMock = httpClientMockPatch[CommentData, Comment](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPatch[CommentData, Comment](
       url = s"repos/$validRepoOwner/$validRepoName/issues/comments/$validCommentId",
       req = request,
-      response = response
+      response = IO.pure(comment)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.editComment(
-      validRepoOwner,
-      validRepoName,
-      validCommentId,
-      validCommentBody,
-      headerUserAgent
-    )
+    issues
+      .editComment(
+        validRepoOwner,
+        validRepoName,
+        validCommentId,
+        validCommentBody,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issue.DeleteComment" should "call to httpClient.delete with the right parameters" in {
 
-    val response: IO[GHResponse[Unit]] =
-      IO(GHResponse(().asRight, noContentStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockDelete(
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockDelete(
       url = s"repos/$validRepoOwner/$validRepoName/issues/comments/$validCommentId",
-      response = response
+      response = IO.unit,
+      responseStatus = http4s.Status.NoContent
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.deleteComment(validRepoOwner, validRepoName, validCommentId, headerUserAgent)
+    issues
+      .deleteComment(validRepoOwner, validRepoName, validCommentId, headerUserAgent)
+      .shouldNotFail
   }
 
   "Issues.ListLabelsRepository" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Label]]] =
-      IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Label]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Label]](
       url = s"repos/$validRepoOwner/$validRepoName/labels",
-      response = response
+      response = IO.pure(List(label))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.listLabelsRepository(validRepoOwner, validRepoName, None, headerUserAgent)
+    issues.listLabelsRepository(validRepoOwner, validRepoName, None, headerUserAgent).shouldNotFail
   }
 
   "Issues.ListLabels" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Label]]] =
-      IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Label]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Label]](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber/labels",
-      response = response
+      response = IO.pure(List(label))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.listLabels(validRepoOwner, validRepoName, validIssueNumber, None, headerUserAgent)
+    issues
+      .listLabels(validRepoOwner, validRepoName, validIssueNumber, None, headerUserAgent)
+      .shouldNotFail
   }
 
   "Issues.CreateLabel" should "call httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[Label]] =
-      IO(GHResponse(validRepoLabel.asRight, okStatusCode, Map.empty))
 
     val request = validRepoLabel
 
-    implicit val httpClientMock = httpClientMockPost[Label, Label](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[Label, Label](
       url = s"repos/$validRepoOwner/$validRepoName/labels",
       req = request,
-      response = response
+      response = IO.pure(validRepoLabel)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.createLabel(
-      validRepoOwner,
-      validRepoName,
-      validRepoLabel,
-      headerUserAgent
-    )
+    issues
+      .createLabel(
+        validRepoOwner,
+        validRepoName,
+        validRepoLabel,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.UpdateLabel" should "call httpClient.patch with the right parameters" in {
-    val response: IO[GHResponse[Label]] =
-      IO(GHResponse(validRepoLabel.asRight, okStatusCode, Map.empty))
 
     val request = validRepoLabel
 
-    implicit val httpClientMock = httpClientMockPatch[Label, Label](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPatch[Label, Label](
       url = s"repos/$validRepoOwner/$validRepoName/labels/${validRepoLabel.name}",
       req = request,
-      response = response
+      response = IO.pure(validRepoLabel)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.updateLabel(
-      validRepoOwner,
-      validRepoName,
-      validRepoLabel,
-      headerUserAgent
-    )
+    issues
+      .updateLabel(
+        validRepoOwner,
+        validRepoName,
+        validRepoLabel,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.DeleteLabel" should "call httpClient.delete with the right parameters" in {
-    val response: IO[GHResponse[Unit]] =
-      IO(GHResponse(().asRight, noContentStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockDelete(
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockDelete(
       url = s"repos/$validRepoOwner/$validRepoName/labels/${validRepoLabel.name}",
-      response = response
+      response = IO.unit,
+      responseStatus = http4s.Status.NoContent
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.deleteLabel(
-      validRepoOwner,
-      validRepoName,
-      validRepoLabel.name,
-      headerUserAgent
-    )
+    issues
+      .deleteLabel(
+        validRepoOwner,
+        validRepoName,
+        validRepoLabel.name,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.AddLabels" should "call httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[List[Label]]] =
-      IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))
 
     val request = validIssueLabel
 
-    implicit val httpClientMock = httpClientMockPost[List[String], List[Label]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[List[String], List[Label]](
       url = s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber/labels",
       req = request,
-      response = response
+      response = IO.pure(List(label))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.addLabels(
-      validRepoOwner,
-      validRepoName,
-      validIssueNumber,
-      validIssueLabel,
-      headerUserAgent
-    )
+    issues
+      .addLabels(
+        validRepoOwner,
+        validRepoName,
+        validIssueNumber,
+        validIssueLabel,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.RemoveLabel" should "call httpClient.delete with the right parameters" in {
-    val response: IO[GHResponse[List[Label]]] =
-      IO(GHResponse(List(label).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockDeleteWithResponse[List[Label]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockDeleteWithResponse[List[Label]](
       url =
         s"repos/$validRepoOwner/$validRepoName/issues/$validIssueNumber/labels/${validIssueLabel.head}",
-      response = response
+      response = IO.pure(List(label))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.removeLabel(
-      validRepoOwner,
-      validRepoName,
-      validIssueNumber,
-      validIssueLabel.head,
-      headerUserAgent
-    )
+    issues
+      .removeLabel(
+        validRepoOwner,
+        validRepoName,
+        validIssueNumber,
+        validIssueLabel.head,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.listAvailableAssignees" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"repos/$validRepoOwner/$validRepoName/assignees",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.listAvailableAssignees(
-      validRepoOwner,
-      validRepoName,
-      Some(Pagination(validPage, validPerPage)),
-      headerUserAgent
-    )
+    issues
+      .listAvailableAssignees(
+        validRepoOwner,
+        validRepoName,
+        Some(Pagination(validPage, validPerPage)),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.listMilestone" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Milestone]]] =
-      IO(GHResponse(Nil.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Milestone]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Milestone]](
       url = s"repos/$validRepoOwner/$validRepoName/milestones",
-      response = response
+      response = IO.pure(Nil)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.listMilestones(
-      validRepoOwner,
-      validRepoName,
-      None,
-      None,
-      None,
-      Some(Pagination(validPage, validPerPage)),
-      headerUserAgent
-    )
+    issues
+      .listMilestones(
+        validRepoOwner,
+        validRepoName,
+        None,
+        None,
+        None,
+        Some(Pagination(validPage, validPerPage)),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.createMilestone" should "call httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[Milestone]] =
-      IO(GHResponse(milestone.asRight, createdStatusCode, Map.empty))
 
     val request = MilestoneData(
       validIssueTitle,
@@ -383,43 +373,42 @@ class IssuesSpec extends BaseSpec {
       Some(ZonedDateTime.parse(validMilestoneDueOn, DateTimeFormatter.ISO_ZONED_DATE_TIME))
     )
 
-    implicit val httpClientMock = httpClientMockPost[MilestoneData, Milestone](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[MilestoneData, Milestone](
       url = s"repos/$validRepoOwner/$validRepoName/milestones",
       req = request,
-      response = response
+      response = IO.pure(milestone),
+      responseStatus = http4s.Status.Created
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.createMilestone(
-      validRepoOwner,
-      validRepoName,
-      validMilestoneTitle,
-      None,
-      None,
-      Some(ZonedDateTime.parse(validMilestoneDueOn, DateTimeFormatter.ISO_ZONED_DATE_TIME)),
-      headerUserAgent
-    )
-
+    issues
+      .createMilestone(
+        validRepoOwner,
+        validRepoName,
+        validMilestoneTitle,
+        None,
+        None,
+        Some(ZonedDateTime.parse(validMilestoneDueOn, DateTimeFormatter.ISO_ZONED_DATE_TIME)),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issues.getMilestone" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[Milestone]] =
-      IO(GHResponse(milestone.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[Milestone](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[Milestone](
       url = s"repos/$validRepoOwner/$validRepoName/milestones/$validMilestoneNumber",
-      response = response
+      response = IO.pure(milestone)
     )
 
     val issues = new IssuesInterpreter[IO]
 
-    issues.getMilestone(validRepoOwner, validRepoName, validMilestoneNumber, headerUserAgent)
-
+    issues
+      .getMilestone(validRepoOwner, validRepoName, validMilestoneNumber, headerUserAgent)
+      .shouldNotFail
   }
   "Issues.updateMilestone" should "call httpClient.patch with the right parameters" in {
-    val response: IO[GHResponse[Milestone]] =
-      IO(GHResponse(milestone.asRight, okStatusCode, Map.empty))
 
     val request = MilestoneData(
       validMilestoneTitle,
@@ -428,36 +417,38 @@ class IssuesSpec extends BaseSpec {
       None
     )
 
-    implicit val httpClientMock = httpClientMockPatch[MilestoneData, Milestone](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPatch[MilestoneData, Milestone](
       url = s"repos/$validRepoOwner/$validRepoName/milestones/$validMilestoneNumber",
       req = request,
-      response = response
+      response = IO.pure(milestone)
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.updateMilestone(
-      validRepoOwner,
-      validRepoName,
-      validMilestoneNumber,
-      validMilestoneTitle,
-      None,
-      None,
-      None,
-      headerUserAgent
-    )
+    issues
+      .updateMilestone(
+        validRepoOwner,
+        validRepoName,
+        validMilestoneNumber,
+        validMilestoneTitle,
+        None,
+        None,
+        None,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Issue.DeleteMilestone" should "call to httpClient.delete with the right parameters" in {
 
-    val response: IO[GHResponse[Unit]] =
-      IO(GHResponse(().asRight, noContentStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockDelete(
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockDelete(
       url = s"repos/$validRepoOwner/$validRepoName/milestones/$validMilestoneNumber",
-      response = response
+      response = IO.unit,
+      responseStatus = http4s.Status.NoContent
     )
 
     val issues = new IssuesInterpreter[IO]
-    issues.deleteMilestone(validRepoOwner, validRepoName, validMilestoneNumber, headerUserAgent)
+    issues
+      .deleteMilestone(validRepoOwner, validRepoName, validMilestoneNumber, headerUserAgent)
+      .shouldNotFail
   }
 }

--- a/github4s/src/test/scala/github4s/unit/OrganizationsSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/OrganizationsSpec.scala
@@ -17,9 +17,9 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
 import github4s.interpreters.OrganizationsInterpreter
 import github4s.utils.BaseSpec
 
@@ -27,31 +27,28 @@ class OrganizationsSpec extends BaseSpec {
 
   "Organization.listMembers" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"orgs/$validRepoOwner/members",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val organizations = new OrganizationsInterpreter[IO]
 
-    organizations.listMembers(validRepoOwner, None, None, None, headerUserAgent)
+    organizations.listMembers(validRepoOwner, None, None, None, headerUserAgent).shouldNotFail
   }
 
   "Organization.listOutsideCollaborators" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"orgs/$validOrganizationName/outside_collaborators",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val organizations = new OrganizationsInterpreter[IO]
 
-    organizations.listOutsideCollaborators(validOrganizationName, None, None, headerUserAgent)
+    organizations
+      .listOutsideCollaborators(validOrganizationName, None, None, headerUserAgent)
+      .shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/ProjectSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/ProjectSpec.scala
@@ -17,9 +17,9 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
 import github4s.interpreters.ProjectsInterpreter
 import github4s.utils.BaseSpec
 
@@ -27,76 +27,67 @@ class ProjectSpec extends BaseSpec {
 
   "Project.listProjects" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[Project]]] =
-      IO(GHResponse(List(project).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[Project]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Project]](
       url = s"orgs/$validRepoOwner/projects",
       headers = headerAccept,
-      response = response
+      response = IO.pure(List(project))
     )
 
     val projects = new ProjectsInterpreter[IO]
 
-    projects.listProjects(validRepoOwner, None, None, headers = headerUserAgent ++ headerAccept)
-
+    projects
+      .listProjects(validRepoOwner, None, None, headers = headerUserAgent ++ headerAccept)
+      .shouldNotFail
   }
 
   "Project.listProjectsRepository" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[Project]]] =
-      IO(GHResponse(List(project).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[Project]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Project]](
       url = s"repos/$validRepoOwner/$validRepoName/projects",
       headers = headerAccept,
-      response = response
+      response = IO.pure(List(project))
     )
 
     val projects = new ProjectsInterpreter[IO]
 
-    projects.listProjectsRepository(
-      validRepoOwner,
-      validRepoName,
-      None,
-      None,
-      headers = headerUserAgent ++ headerAccept
-    )
+    projects
+      .listProjectsRepository(
+        validRepoOwner,
+        validRepoName,
+        None,
+        None,
+        headers = headerUserAgent ++ headerAccept
+      )
+      .shouldNotFail
 
   }
 
   "Project.listColumns" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[Column]]] =
-      IO(GHResponse(List(column).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[Column]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Column]](
       url = s"projects/$validProjectId/columns",
       headers = headerAccept,
-      response = response
+      response = IO.pure(List(column))
     )
 
     val projects = new ProjectsInterpreter[IO]
 
-    projects.listColumns(validProjectId, None, headers = headerUserAgent ++ headerAccept)
-
+    projects
+      .listColumns(validProjectId, None, headers = headerUserAgent ++ headerAccept)
+      .shouldNotFail
   }
 
   "Project.listCards" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[Card]]] =
-      IO(GHResponse(List(card).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[Card]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Card]](
       url = s"projects/columns/$validColumnId/cards",
       headers = headerAccept,
-      response = response
+      response = IO.pure(List(card))
     )
 
     val project = new ProjectsInterpreter[IO]
 
-    project.listCards(validColumnId, None, None, headerUserAgent ++ headerAccept)
-
+    project.listCards(validColumnId, None, None, headerUserAgent ++ headerAccept).shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/PullRequestsSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/PullRequestsSpec.scala
@@ -17,65 +17,58 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
-import github4s.interpreters.PullRequestsInterpreter
+import github4s.Decoders._
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
+import github4s.interpreters.PullRequestsInterpreter
 import github4s.utils.BaseSpec
 
 class PullRequestsSpec extends BaseSpec {
 
   "PullRequests.get" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[PullRequest]] =
-      IO(GHResponse(pullRequest.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[PullRequest](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[PullRequest](
       url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber",
-      response = response
+      response = IO.pure(pullRequest)
     )
     val pullRequests = new PullRequestsInterpreter[IO]
-    pullRequests.getPullRequest(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      headerUserAgent
-    )
+    pullRequests
+      .getPullRequest(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        headerUserAgent
+      )
+      .shouldNotFail
 
   }
 
   "PullRequests.list" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[PullRequest]]] =
-      IO(GHResponse(List(pullRequest).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[PullRequest]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[PullRequest]](
       url = s"repos/$validRepoOwner/$validRepoName/pulls",
-      response = response
+      response = IO.pure(List(pullRequest))
     )
     val pullRequests = new PullRequestsInterpreter[IO]
-    pullRequests.listPullRequests(validRepoOwner, validRepoName, Nil, None, headerUserAgent)
-
+    pullRequests
+      .listPullRequests(validRepoOwner, validRepoName, Nil, None, headerUserAgent)
+      .shouldNotFail
   }
 
   "PullRequests.listFiles" should "call to httpClient.get with the right parameters" in {
 
-    val response: IO[GHResponse[List[PullRequestFile]]] =
-      IO(GHResponse(List(pullRequestFile).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[PullRequestFile]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[PullRequestFile]](
       url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/files",
-      response = response
+      response = IO.pure(List(pullRequestFile))
     )
     val pullRequests = new PullRequestsInterpreter[IO]
     pullRequests
       .listFiles(validRepoOwner, validRepoName, validPullRequestNumber, None, headerUserAgent)
-
+      .shouldNotFail
   }
 
   "PullRequests.create data" should "call to httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[PullRequest]] =
-      IO(GHResponse(pullRequest.asRight, okStatusCode, Map.empty))
 
     val request = CreatePullRequestData(
       "Amazing new feature",
@@ -86,180 +79,186 @@ class PullRequestsSpec extends BaseSpec {
       draft
     )
 
-    implicit val httpClientMock = httpClientMockPost[CreatePullRequestData, PullRequest](
-      url = s"repos/$validRepoOwner/$validRepoName/pulls",
-      req = request,
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.createPullRequest(
-      validRepoOwner,
-      validRepoName,
-      validNewPullRequestData,
-      validHead,
-      validBase,
-      Some(true),
-      headerUserAgent
-    )
-
-  }
-
-  "PullRequests.create issue" should "call to httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[PullRequest]] =
-      IO(GHResponse(pullRequest.asRight, okStatusCode, Map.empty))
-
-    val request = CreatePullRequestIssue(31, validHead, validBase, Some(true))
-
-    implicit val httpClientMock = httpClientMockPost[CreatePullRequestIssue, PullRequest](
-      url = s"repos/$validRepoOwner/$validRepoName/pulls",
-      req = request,
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.createPullRequest(
-      validRepoOwner,
-      validRepoName,
-      validNewPullRequestIssue,
-      validHead,
-      validBase,
-      Some(true),
-      headerUserAgent
-    )
-
-  }
-
-  "PullRequests.listReviews" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[PullRequestReview]]] =
-      IO(GHResponse(List(pullRequestReview).asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[List[PullRequestReview]](
-      url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews",
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.listReviews(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      None,
-      headerUserAgent
-    )
-
-  }
-
-  "PullRequests.getReview" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[PullRequestReview]] =
-      IO(GHResponse(pullRequestReview.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockGet[PullRequestReview](
-      url =
-        s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews/$validPullRequestReviewNumber",
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.getReview(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      validPullRequestReviewNumber,
-      headerUserAgent
-    )
-
-  }
-
-  "PullRequests.createReview" should "call to httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[PullRequestReview]] =
-      IO(GHResponse(pullRequestReview.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockPost[CreatePRReviewRequest, PullRequestReview](
-      url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews",
-      req = validCreatePRReviewRequest,
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.createReview(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      validCreatePRReviewRequest,
-      headerUserAgent
-    )
-  }
-
-  "PullRequests.addReviewers" should "call to httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[PullRequestReview]] =
-      IO(GHResponse(pullRequestReview.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock = httpClientMockPost[ReviewersRequest, PullRequestReview](
-      url =
-        s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
-      req = validRequestedReviewersRequest,
-      response = response
-    )
-
-    val pullRequests = new PullRequestsInterpreter[IO]
-
-    pullRequests.addReviewers(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      validRequestedReviewersRequest,
-      headerUserAgent
-    )
-  }
-
-  "PullRequests.removeReviewers" should "call to httpClient.delete with the right parameters" in {
-    val response: IO[GHResponse[PullRequestReview]] =
-      IO(GHResponse(pullRequestReview.asRight, okStatusCode, Map.empty))
-
-    implicit val httpClientMock =
-      httpClientMockDeleteWithBody[ReviewersRequest, PullRequestReview](
-        url =
-          s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
-        req = validRequestedReviewersRequest,
-        response = response
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPost[CreatePullRequestData, PullRequest](
+        url = s"repos/$validRepoOwner/$validRepoName/pulls",
+        req = request,
+        response = IO.pure(pullRequest)
       )
 
     val pullRequests = new PullRequestsInterpreter[IO]
 
-    pullRequests.removeReviewers(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      validRequestedReviewersRequest,
-      headerUserAgent
-    )
+    pullRequests
+      .createPullRequest(
+        validRepoOwner,
+        validRepoName,
+        validNewPullRequestData,
+        validHead,
+        validBase,
+        Some(true),
+        headerUserAgent
+      )
+      .shouldNotFail
+
   }
 
-  "PullRequests.listReviewers" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[ReviewersResponse]] =
-      IO(GHResponse(validRequestedReviewersResponse.asRight, okStatusCode, Map.empty))
+  "PullRequests.create issue" should "call to httpClient.post with the right parameters" in {
 
-    implicit val httpClientMock = httpClientMockGet[ReviewersResponse](
-      url =
-        s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
-      response = response
+    val request = CreatePullRequestIssue(31, validHead, validBase, Some(true))
+
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPost[CreatePullRequestIssue, PullRequest](
+        url = s"repos/$validRepoOwner/$validRepoName/pulls",
+        req = request,
+        response = IO.pure(pullRequest)
+      )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .createPullRequest(
+        validRepoOwner,
+        validRepoName,
+        validNewPullRequestIssue,
+        validHead,
+        validBase,
+        Some(true),
+        headerUserAgent
+      )
+      .shouldNotFail
+
+  }
+
+  "PullRequests.listReviews" should "call to httpClient.get with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[PullRequestReview]](
+      url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews",
+      response = IO.pure(List(pullRequestReview))
     )
 
     val pullRequests = new PullRequestsInterpreter[IO]
 
-    pullRequests.listReviewers(
-      validRepoOwner,
-      validRepoName,
-      validPullRequestNumber,
-      None,
-      headerUserAgent
+    pullRequests
+      .listReviews(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        None,
+        headerUserAgent
+      )
+      .shouldNotFail
+
+  }
+
+  "PullRequests.getReview" should "call to httpClient.get with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[PullRequestReview](
+      url =
+        s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews/$validPullRequestReviewNumber",
+      response = IO.pure(pullRequestReview)
     )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .getReview(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        validPullRequestReviewNumber,
+        headerUserAgent
+      )
+      .shouldNotFail
+
+  }
+
+  "PullRequests.createReview" should "call to httpClient.post with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPost[CreatePRReviewRequest, PullRequestReview](
+        url = s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/reviews",
+        req = validCreatePRReviewRequest,
+        response = IO.pure(pullRequestReview)
+      )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .createReview(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        validCreatePRReviewRequest,
+        headerUserAgent
+      )
+      .shouldNotFail
+  }
+
+  "PullRequests.addReviewers" should "call to httpClient.post with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPost[ReviewersRequest, PullRequestReview](
+        url =
+          s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
+        req = validRequestedReviewersRequest,
+        response = IO.pure(pullRequestReview)
+      )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .addReviewers(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        validRequestedReviewersRequest,
+        headerUserAgent
+      )
+      .shouldNotFail
+  }
+
+  "PullRequests.removeReviewers" should "call to httpClient.delete with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockDeleteWithBody[ReviewersRequest, PullRequestReview](
+        url =
+          s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
+        req = validRequestedReviewersRequest,
+        response = IO.pure(pullRequestReview)
+      )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .removeReviewers(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        validRequestedReviewersRequest,
+        headerUserAgent
+      )
+      .shouldNotFail
+  }
+
+  "PullRequests.listReviewers" should "call to httpClient.get with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[ReviewersResponse](
+      url =
+        s"repos/$validRepoOwner/$validRepoName/pulls/$validPullRequestNumber/requested_reviewers",
+      response = IO.pure(validRequestedReviewersResponse)
+    )
+
+    val pullRequests = new PullRequestsInterpreter[IO]
+
+    pullRequests
+      .listReviewers(
+        validRepoOwner,
+        validRepoName,
+        validPullRequestNumber,
+        None,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/ReposSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/ReposSpec.scala
@@ -18,124 +18,114 @@ package github4s.unit
 
 import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.syntax.either._
-import com.github.marklister.base64.Base64._
-import github4s.GHResponse
+import github4s.Decoders._
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
+import com.github.marklister.base64.Base64._
 import github4s.interpreters.RepositoriesInterpreter
 import github4s.utils.BaseSpec
+import org.http4s
 
 class ReposSpec extends BaseSpec {
 
   "Repos.get" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[Repository]] =
-      IO(GHResponse(repo.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[Repository](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[Repository](
       url = s"repos/$validRepoOwner/$validRepoName",
-      response = response
+      response = IO.pure(repo)
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.get(validRepoOwner, validRepoName, headerUserAgent)
+    repos.get(validRepoOwner, validRepoName, headerUserAgent).shouldNotFail
   }
 
   "Repos.listReleases" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Release]]] =
-      IO(GHResponse(List(release).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Release]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Release]](
       url = s"repos/$validRepoOwner/$validRepoName/releases",
-      response = response
+      response = IO.pure(List(release))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listReleases(validRepoOwner, validRepoName, None, headers = headerUserAgent)
+    repos.listReleases(validRepoOwner, validRepoName, None, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.latestRelease" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[Option[Release]]] =
-      IO(GHResponse(Option(release).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[Option[Release]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[Option[Release]](
       url = s"repos/$validRepoOwner/$validRepoName/releases/latest",
-      response = response
+      response = IO.pure(Option(release))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.latestRelease(validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos.latestRelease(validRepoOwner, validRepoName, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.getRelease" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[Option[Release]]] =
-      IO(GHResponse(Option(release).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[Option[Release]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[Option[Release]](
       url = s"repos/$validRepoOwner/$validRepoName/releases/${release.id}",
-      response = response
+      response = IO.pure(Option(release))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.getRelease(release.id, validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos
+      .getRelease(release.id, validRepoOwner, validRepoName, headers = headerUserAgent)
+      .shouldNotFail
   }
 
   "Repos.listOrgRepos" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Repository]]] =
-      IO(GHResponse(List(repo).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Repository]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Repository]](
       url = s"orgs/$validRepoOwner/repos",
-      response = response
+      response = IO.pure(List(repo))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listOrgRepos(validRepoOwner, headers = headerUserAgent)
+    repos.listOrgRepos(validRepoOwner, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.listUserRepos" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Repository]]] =
-      IO(GHResponse(List(repo).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Repository]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Repository]](
       url = s"users/$validRepoOwner/repos",
-      response = response
+      response = IO.pure(List(repo))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listUserRepos(validRepoOwner, headers = headerUserAgent)
+    repos.listUserRepos(validRepoOwner, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.getContents" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[NonEmptyList[Content]]] =
-      IO(GHResponse(NonEmptyList.one(content).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[NonEmptyList[Content]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[NonEmptyList[Content]](
       url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
       params = Map("ref" -> "master"),
-      response = response
+      response = IO.pure(NonEmptyList.one(content))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.getContents(
-      validRepoOwner,
-      validRepoName,
-      validFilePath,
-      Some("master"),
-      None,
-      headerUserAgent
-    )
+    repos
+      .getContents(
+        validRepoOwner,
+        validRepoName,
+        validFilePath,
+        Some("master"),
+        None,
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.createFile" should "call to httpClient.put with the right parameters" in {
-    val response: IO[GHResponse[WriteFileResponse]] =
-      IO(GHResponse(writeFileResponse.asRight, okStatusCode, Map.empty))
 
     val request = WriteFileRequest(
       validNote,
@@ -146,30 +136,31 @@ class ReposSpec extends BaseSpec {
       Some(validCommitter)
     )
 
-    implicit val httpClientMock = httpClientMockPut[WriteFileRequest, WriteFileResponse](
-      url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
-      req = request,
-      response = response
-    )
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPut[WriteFileRequest, WriteFileResponse](
+        url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
+        req = request,
+        response = IO.pure(writeFileResponse)
+      )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.createFile(
-      validRepoOwner,
-      validRepoName,
-      validFilePath,
-      validNote,
-      validFileContent.getBytes,
-      Some(validBranchName),
-      Some(validCommitter),
-      Some(validCommitter),
-      headerUserAgent
-    )
+    repos
+      .createFile(
+        validRepoOwner,
+        validRepoName,
+        validFilePath,
+        validNote,
+        validFileContent.getBytes,
+        Some(validBranchName),
+        Some(validCommitter),
+        Some(validCommitter),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.updateFile" should "call to httpClient.put with the right parameters" in {
-    val response: IO[GHResponse[WriteFileResponse]] =
-      IO(GHResponse(writeFileResponse.asRight, okStatusCode, Map.empty))
 
     val request = WriteFileRequest(
       validNote,
@@ -180,31 +171,32 @@ class ReposSpec extends BaseSpec {
       Some(validCommitter)
     )
 
-    implicit val httpClientMock = httpClientMockPut[WriteFileRequest, WriteFileResponse](
-      url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
-      req = request,
-      response = response
-    )
+    implicit val httpClientMock: HttpClient[IO] =
+      httpClientMockPut[WriteFileRequest, WriteFileResponse](
+        url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
+        req = request,
+        response = IO.pure(writeFileResponse)
+      )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.updateFile(
-      validRepoOwner,
-      validRepoName,
-      validFilePath,
-      validNote,
-      validFileContent.getBytes,
-      validCommitSha,
-      Some(validBranchName),
-      Some(validCommitter),
-      Some(validCommitter),
-      headerUserAgent
-    )
+    repos
+      .updateFile(
+        validRepoOwner,
+        validRepoName,
+        validFilePath,
+        validNote,
+        validFileContent.getBytes,
+        validCommitSha,
+        Some(validBranchName),
+        Some(validCommitter),
+        Some(validCommitter),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.deleteFile" should "call to httpClient.delete with the right parameters" in {
-    val response: IO[GHResponse[WriteFileResponse]] =
-      IO(GHResponse(writeFileResponse.asRight, okStatusCode, Map.empty))
 
     val request = DeleteFileRequest(
       validNote,
@@ -214,30 +206,31 @@ class ReposSpec extends BaseSpec {
       Some(validCommitter)
     )
 
-    implicit val httpClientMock =
+    implicit val httpClientMock: HttpClient[IO] =
       httpClientMockDeleteWithBody[DeleteFileRequest, WriteFileResponse](
         url = s"repos/$validRepoOwner/$validRepoName/contents/$validFilePath",
         req = request,
-        response = response
+        response = IO.pure(writeFileResponse)
       )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.deleteFile(
-      validRepoOwner,
-      validRepoName,
-      validFilePath,
-      validNote,
-      validCommitSha,
-      Some(validBranchName),
-      Some(validCommitter),
-      Some(validCommitter),
-      headerUserAgent
-    )
+    repos
+      .deleteFile(
+        validRepoOwner,
+        validRepoName,
+        validFilePath,
+        validNote,
+        validCommitSha,
+        Some(validBranchName),
+        Some(validCommitter),
+        Some(validCommitter),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.createRelease" should "call to httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[Release]] = IO(GHResponse(release.asRight, okStatusCode, Map.empty))
 
     val request = NewReleaseRequest(
       validTagTitle,
@@ -248,203 +241,197 @@ class ReposSpec extends BaseSpec {
       Some(true)
     )
 
-    implicit val httpClientMock = httpClientMockPost[NewReleaseRequest, Release](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[NewReleaseRequest, Release](
       url = s"repos/$validRepoOwner/$validRepoName/releases",
       req = request,
-      response = response
+      response = IO.pure(release)
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.createRelease(
-      validRepoOwner,
-      validRepoName,
-      validTagTitle,
-      validTagTitle,
-      validNote,
-      Some("master"),
-      Some(false),
-      Some(true),
-      headerUserAgent
-    )
+    repos
+      .createRelease(
+        validRepoOwner,
+        validRepoName,
+        validTagTitle,
+        validTagTitle,
+        validNote,
+        Some("master"),
+        Some(false),
+        Some(true),
+        headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.listCommits" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Commit]]] =
-      IO(GHResponse(List(commit).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Commit]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Commit]](
       url = s"repos/$validRepoOwner/$validRepoName/commits",
-      response = response
+      response = IO.pure(List(commit))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listCommits(validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos.listCommits(validRepoOwner, validRepoName, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.listBranches" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Branch]]] =
-      IO(GHResponse(List(branch).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Branch]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Branch]](
       url = s"repos/$validRepoOwner/$validRepoName/branches",
-      response = response
+      response = IO.pure(List(branch))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listBranches(validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos.listBranches(validRepoOwner, validRepoName, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.listBranches" should "list protected branches only" in {
-    val response: IO[GHResponse[List[Branch]]] =
-      IO(GHResponse(List(protectedBranch).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Branch]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Branch]](
       url = s"repos/$validRepoOwner/$validRepoName/branches",
       params = Map("protected" -> "true"),
-      response = response
+      response = IO.pure(List(protectedBranch))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listBranches(validRepoOwner, validRepoName, Some(true), None, headerUserAgent)
+    repos
+      .listBranches(validRepoOwner, validRepoName, Some(true), None, headerUserAgent)
+      .shouldNotFail
   }
 
   "Repos.listContributors" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"repos/$validRepoOwner/$validRepoName/contributors",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listContributors(validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos.listContributors(validRepoOwner, validRepoName, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.listCollaborators" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"repos/$validRepoOwner/$validRepoName/collaborators",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listCollaborators(validRepoOwner, validRepoName, headers = headerUserAgent)
+    repos.listCollaborators(validRepoOwner, validRepoName, headers = headerUserAgent).shouldNotFail
   }
 
   "Repos.userIsCollaborator" should "call to httpClient.getWithoutResponse with the right parameters" in {
-    val response: IO[GHResponse[Unit]] =
-      IO(GHResponse(().asRight, noContentStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGetWithoutResponse(
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGetWithoutResponse(
       url = s"repos/$validRepoOwner/$validRepoName/collaborators/$validUsername",
-      response = response
+      response = IO.unit,
+      responseStatus = http4s.Status.NoContent
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.userIsCollaborator(
-      validRepoOwner,
-      validRepoName,
-      validUsername,
-      headers = headerUserAgent
-    )
+    repos
+      .userIsCollaborator(
+        validRepoOwner,
+        validRepoName,
+        validUsername,
+        headers = headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.getRepoPermissionForUser" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[UserRepoPermission]] =
-      IO(GHResponse(userRepoPermission.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[UserRepoPermission](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[UserRepoPermission](
       url = s"repos/$validRepoOwner/$validRepoName/collaborators/$validUsername/permission",
-      response = response
+      response = IO.pure(userRepoPermission)
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.getRepoPermissionForUser(
-      validRepoOwner,
-      validRepoName,
-      validUsername,
-      headers = headerUserAgent
-    )
+    repos
+      .getRepoPermissionForUser(
+        validRepoOwner,
+        validRepoName,
+        validUsername,
+        headers = headerUserAgent
+      )
+      .shouldNotFail
   }
 
   "Repos.getCombinedStatus" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[CombinedStatus]] =
-      IO(GHResponse(combinedStatus.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[CombinedStatus](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[CombinedStatus](
       url = s"repos/$validRepoOwner/$validRepoName/commits/$validRefSingle/status",
-      response = response
+      response = IO.pure(combinedStatus)
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.getCombinedStatus(validRepoOwner, validRepoName, validRefSingle, headerUserAgent)
+    repos
+      .getCombinedStatus(validRepoOwner, validRepoName, validRefSingle, headerUserAgent)
+      .shouldNotFail
   }
 
   "Repos.listStatuses" should "call htppClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Status]]] =
-      IO(GHResponse(List(status).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Status]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Status]](
       url = s"repos/$validRepoOwner/$validRepoName/commits/$validRefSingle/statuses",
-      response = response
+      response = IO.pure(List(status))
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.listStatuses(validRepoOwner, validRepoName, validRefSingle, None, headerUserAgent)
+    repos
+      .listStatuses(validRepoOwner, validRepoName, validRefSingle, None, headerUserAgent)
+      .shouldNotFail
   }
 
   "Repos.createStatus" should "call httpClient.post with the right parameters" in {
-    val response: IO[GHResponse[Status]] =
-      IO(GHResponse(status.asRight, createdStatusCode, Map.empty))
 
     val request = NewStatusRequest(validStatusState, None, None, None)
 
-    implicit val httpClientMock = httpClientMockPost[NewStatusRequest, Status](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockPost[NewStatusRequest, Status](
       url = s"repos/$validRepoOwner/$validRepoName/statuses/$validCommitSha",
       req = request,
-      response = response
+      response = IO.pure(status),
+      responseStatus = http4s.Status.Created
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.createStatus(
-      validRepoOwner,
-      validRepoName,
-      validCommitSha,
-      validStatusState,
-      None,
-      None,
-      None,
-      headerUserAgent
-    )
+    repos
+      .createStatus(
+        validRepoOwner,
+        validRepoName,
+        validCommitSha,
+        validStatusState,
+        None,
+        None,
+        None,
+        headerUserAgent
+      )
+      .shouldNotFail
 
   }
 
   "Repos.searchRepos" should "call httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[SearchReposResult]] =
-      IO(GHResponse(searchReposResult.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[SearchReposResult](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[SearchReposResult](
       url = "search/repositories",
       params = Map("q" -> s"+${validSearchParams.map(_.value).mkString("+")}"),
-      response = response
+      response = IO.pure(searchReposResult)
     )
 
     val repos = new RepositoriesInterpreter[IO]
 
-    repos.searchRepos("", validSearchParams, None, headerUserAgent)
+    repos.searchRepos("", validSearchParams, None, headerUserAgent).shouldNotFail
   }
 }

--- a/github4s/src/test/scala/github4s/unit/TeamsSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/TeamsSpec.scala
@@ -17,26 +17,24 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
 import github4s.interpreters.TeamsInterpreter
 import github4s.utils.BaseSpec
 
 class TeamsSpec extends BaseSpec {
 
   "Teams.listTeam" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[Team]]] =
-      IO(GHResponse(List(team).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[Team]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[Team]](
       url = s"orgs/$validRepoOwner/teams",
-      response = response
+      response = IO.pure(List(team))
     )
 
     val teams = new TeamsInterpreter[IO]
 
-    teams.listTeams(validRepoOwner, headers = headerUserAgent)
+    teams.listTeams(validRepoOwner, headers = headerUserAgent).shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/unit/UserSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/UserSpec.scala
@@ -17,67 +17,59 @@
 package github4s.unit
 
 import cats.effect.IO
-import cats.syntax.either._
-import github4s.GHResponse
-import github4s.interpreters.UsersInterpreter
+import github4s.Encoders._
 import github4s.domain._
+import github4s.http.HttpClient
+import github4s.interpreters.UsersInterpreter
 import github4s.utils.BaseSpec
 
 class UserSpec extends BaseSpec {
 
   "UsersInterpreter.get" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[User]] =
-      IO(GHResponse(user.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[User](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[User](
       url = s"users/$validUsername",
-      response = response
+      response = IO.pure(user)
     )
 
     val users = new UsersInterpreter[IO]
-    users.get(validUsername, headerUserAgent)
+    users.get(validUsername, headerUserAgent).shouldNotFail
   }
 
   "User.getAuth" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[User]] =
-      IO(GHResponse(user.asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[User](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[User](
       url = "user",
-      response = response
+      response = IO.pure(user)
     )
 
     val users = new UsersInterpreter[IO]
-    users.getAuth(headerUserAgent)
+    users.getAuth(headerUserAgent).shouldNotFail
   }
 
   "User.getUsers" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
     val request = Map("since" -> 1.toString)
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = "users",
       params = request,
-      response = response
+      response = IO.pure(List(user))
     )
 
     val users = new UsersInterpreter[IO]
-    users.getUsers(1, None, headerUserAgent)
+    users.getUsers(1, None, headerUserAgent).shouldNotFail
   }
 
   "User.getFollowing" should "call to httpClient.get with the right parameters" in {
-    val response: IO[GHResponse[List[User]]] =
-      IO(GHResponse(List(user).asRight, okStatusCode, Map.empty))
 
-    implicit val httpClientMock = httpClientMockGet[List[User]](
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[User]](
       url = s"users/$validUsername/following",
-      response = response
+      response = IO.pure(List(user))
     )
 
     val users = new UsersInterpreter[IO]
-    users.getFollowing(validUsername, None, headerUserAgent)
+    users.getFollowing(validUsername, None, headerUserAgent).shouldNotFail
   }
 
 }

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -19,12 +19,12 @@ package github4s.utils
 import java.util.UUID
 
 import com.github.marklister.base64.Base64._
-import github4s.domain.{Stargazer, StarredRepository, Subscription, _}
+import github4s.domain._
 
 trait TestData {
 
-  val sampleToken: Option[String]          = Some("token")
-  val headerUserAgent: Map[String, String] = Map("user-agent" -> "github4s")
+  val sampleToken: Option[String] = Some("token")
+  val headerUserAgent             = Map("user-agent" -> "github4s")
   val headerAccept: Map[String, String] = Map(
     "Accept" -> "application/vnd.github.inertia-preview+json"
   )

--- a/github4s/src/test/scala/org/scalacheck/fortyseven/GenInstances.scala
+++ b/github4s/src/test/scala/org/scalacheck/fortyseven/GenInstances.scala
@@ -1,0 +1,76 @@
+package org.scalacheck.fortyseven
+// Note: Needs to be in org.scalacheck to access package-private methods
+
+import cats._
+import cats.syntax.all._
+import org.scalacheck.Gen
+
+object GenInstances extends GenInstances
+
+trait GenInstances extends GenInstances1
+
+/*
+Copyright Chris Davenport, 2020
+
+MIT License: https://github.com/davenverse/cats-scalacheck/blob/main/LICENSE
+
+Original source at: https://github.com/davenverse/cats-scalacheck/blob/a17cfeadb7caf07374676994d9066eca4319a8fc/core/shared/src/main/scala/org/scalacheck/cats/instances/GenInstances.scala
+
+Copied here since cats-scalacheck isn't yet published for scala3. This can be deleted once it is
+ */
+
+sealed private[fortyseven] trait GenInstances1 extends GenInstances0 {
+  implicit val genInstances: Monad[Gen] with Alternative[Gen] with FunctorFilter[Gen] =
+    new Monad[Gen] with Alternative[Gen] with FunctorFilter[Gen] {
+      // Members declared in cats.Applicative
+      override def pure[A](x: A): Gen[A] =
+        Gen.const(x)
+
+      // Members declared in cats.FlatMap
+      override def flatMap[A, B](fa: Gen[A])(f: A => Gen[B]): Gen[B] =
+        fa.flatMap(f)
+      override def tailRecM[A, B](a: A)(f: A => Gen[Either[A, B]]): Gen[B] =
+        Gen.tailRecM(a)(f)
+
+      override def combineK[A](x: Gen[A], y: Gen[A]): Gen[A] = Gen.gen { (params, seed) =>
+        val xGen = x.doApply(params, seed)
+        if (xGen.retrieve.isDefined) xGen
+        else y.doApply(params, seed)
+      }
+
+      override def empty[A]: Gen[A] = Gen.fail
+
+      override def map2Eval[A, B, Z](fa: Gen[A], fb: Eval[Gen[B]])(f: (A, B) => Z): Eval[Gen[Z]] =
+        Eval.later(map2(fa, Gen.lzy(fb.value))(f))
+
+      override def product[A, B](fa: Gen[A], fb: Gen[B]): Gen[(A, B)] = Gen.zip(fa, fb)
+
+      override def functor: Functor[Gen] = this
+
+      override def mapFilter[A, B](fa: Gen[A])(f: A => Option[B]): Gen[B] =
+        fa.flatMap { a =>
+          f(a) match {
+            case Some(b) => pure(b)
+            case _       => Gen.fail
+          }
+        }
+    }
+
+  implicit def genMonoid[A: Monoid]: Monoid[Gen[A]] = new Monoid[Gen[A]] {
+    override def empty: Gen[A] = Gen.const(Monoid[A].empty)
+    override def combine(x: Gen[A], y: Gen[A]) = for {
+      xa <- x
+      ya <- y
+    } yield xa |+| ya
+  }
+
+}
+
+sealed private[fortyseven] trait GenInstances0 {
+  implicit def genSemigroup[A: Semigroup]: Semigroup[Gen[A]] = new Semigroup[Gen[A]] {
+    override def combine(x: Gen[A], y: Gen[A]) = for {
+      xa <- x
+      ya <- y
+    } yield xa |+| ya
+  }
+}

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -14,14 +14,17 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val base64: String    = "0.3.0"
-      val cats: String      = "2.6.1"
-      val circe: String     = "0.14.1"
-      val http4s: String    = "0.21.24"
-      val paradise: String  = "2.1.1"
-      val scalamock: String = "5.1.0"
-      val scalatest: String = "3.2.9"
-      val silencer: String  = "1.7.1"
+      val bm4                     = "0.3.1"
+      val base64: String          = "0.3.0"
+      val cats: String            = "2.6.1"
+      val circe: String           = "0.14.1"
+      val expecty                 = "0.15.4"
+      val http4s: String          = "0.21.24"
+      val paradise: String        = "2.1.1"
+      val scalacheck              = "1.15.4"
+      val scalacheckShapeless     = "1.3.0"
+      val scalacheckPlusScalatest = "3.2.9.0"
+      val scalatest: String       = "3.2.9"
     }
 
     lazy val docsMappingsAPIDir: SettingKey[String] =
@@ -69,19 +72,26 @@ object ProjectPlugin extends AutoPlugin {
         "org.typelevel"         %% "cats-core"           % V.cats,
         "io.circe"              %% "circe-core"          % V.circe,
         "io.circe"              %% "circe-generic"       % V.circe,
-        "io.circe"              %% "circe-literal"       % V.circe,
         "com.github.marklister" %% "base64"              % V.base64,
         "org.http4s"            %% "http4s-client"       % V.http4s,
         "org.http4s"            %% "http4s-circe"        % V.http4s,
-        "io.circe"              %% "circe-parser"        % V.circe     % Test,
-        "org.scalamock"         %% "scalamock"           % V.scalamock % Test,
-        "org.scalatest"         %% "scalatest"           % V.scalatest % Test,
-        "org.http4s"            %% "http4s-blaze-client" % V.http4s    % Test,
-        "com.github.ghik"        % "silencer-lib"        % V.silencer  % Provided cross CrossVersion.full,
-        compilerPlugin("com.github.ghik" % "silencer-plugin" % V.silencer cross CrossVersion.full)
+        "io.circe"              %% "circe-parser"        % V.circe                   % Test,
+        "com.eed3si9n.expecty"  %% "expecty"             % V.expecty                 % Test,
+        "org.scalatest"         %% "scalatest"           % V.scalatest               % Test,
+        "org.http4s"            %% "http4s-blaze-client" % V.http4s                  % Test,
+        "org.http4s"            %% "http4s-dsl"          % V.http4s                  % Test,
+        "org.http4s"            %% "http4s-server"       % V.http4s                  % Test,
+        "org.scalacheck"        %% "scalacheck"          % V.scalacheck              % Test,
+        "org.scalatestplus"     %% "scalacheck-1-15"     % V.scalacheckPlusScalatest % Test
       ),
       libraryDependencies ++= on(2, 12)(
         compilerPlugin("org.scalamacros" %% "paradise" % V.paradise cross CrossVersion.full)
+      ).value,
+      libraryDependencies ++= on(2)(
+        "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % V.scalacheckShapeless % Test
+      ).value,
+      libraryDependencies ++= on(2)(
+        compilerPlugin("com.olegpy" %% "better-monadic-for" % V.bm4)
       ).value
     )
 
@@ -98,6 +108,14 @@ object ProjectPlugin extends AutoPlugin {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some(v) if v == (major, minor) => Seq(a)
         case _                              => Nil
+      }
+    }
+
+  def on[A](major: Int)(a: A): Def.Initialize[Seq[A]] =
+    Def.setting {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some(v) if v._1 == major => Seq(a)
+        case _                        => Nil
       }
     }
 }


### PR DESCRIPTION
This is needed for scala3

This PR was extracted from #667 

This adds explicit circe encoders and decoders; no more auto-derivation.

This is needed for the new tests, which have to be able to round trip responses through http entities, rather than mocking at the object level.