### PR TITLE
Vendor in base64 source code

### DIFF
--- a/github4s/src/main/scala/github4s/internal/Base64.scala
+++ b/github4s/src/main/scala/github4s/internal/Base64.scala
@@ -1,0 +1,117 @@
+package github4s.internal
+
+import scala.collection.mutable.ArrayBuilder
+
+/**
+ * Base64 encoder
+ * @author
+ *   Mark Lister This software is distributed under the 2-Clause BSD license. See the LICENSE file
+ *   in the root of the repository.
+ *
+ * Copyright (c) 2014 - 2015 Mark Lister
+ *
+ * The repo for this Base64 encoder lives at https://github.com/marklister/base64 Please send your
+ * issues, suggestions and pull requests there.
+ */
+
+private[github4s] object Base64 {
+
+  case class B64Scheme(
+      encodeTable: Array[Char],
+      strictPadding: Boolean = true,
+      postEncode: String => String = identity,
+      preDecode: String => String = identity
+  ) {
+    lazy val decodeTable: Array[Int] = {
+      val b: Array[Int] = new Array[Int](256)
+      for (x <- encodeTable.zipWithIndex)
+        b(x._1.toInt) = x._2
+      b
+    }
+  }
+
+  val base64 = new B64Scheme(
+    (('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9') ++ Seq('+', '/')).toArray
+  )
+  val base64Url = new B64Scheme(
+    base64.encodeTable.dropRight(2) ++ Seq('-', '_'),
+    false,
+    _.replace("=", "%3D"),
+    _.replace("%3D", "=")
+  )
+
+  implicit class SeqEncoder(s: Seq[Byte]) {
+    def toBase64(implicit scheme: B64Scheme = base64): String = Encoder(s.toArray).toBase64
+  }
+
+  implicit class Encoder(b: Array[Byte]) {
+    private[this] val r = new java.lang.StringBuilder((b.length + 3) * 4 / 3)
+    lazy val pad: Int   = (3 - b.length % 3) % 3
+
+    def toBase64(implicit scheme: B64Scheme = base64): String = {
+      def sixBits(x: Byte, y: Byte, z: Byte): Unit = {
+        val zz = (x & 0xff) << 16 | (y & 0xff) << 8 | (z & 0xff)
+        r append scheme.encodeTable(zz >> 18)
+        r append scheme.encodeTable(zz >> 12 & 0x3f)
+        r append scheme.encodeTable(zz >> 6 & 0x3f)
+        r append scheme.encodeTable(zz & 0x3f)
+        ()
+      }
+      for (p <- 0 until b.length - 2 by 3)
+        sixBits(b(p), b(p + 1), b(p + 2))
+      pad match {
+        case 0 =>
+        case 1 => sixBits(b(b.length - 2), b(b.length - 1), 0)
+        case 2 => sixBits(b(b.length - 1), 0, 0)
+      }
+      r setLength (r.length - pad)
+      r append "=" * pad
+      scheme.postEncode(r.toString)
+    }
+  }
+
+  implicit class Decoder(s: String) {
+
+    def toByteArray(implicit scheme: B64Scheme = base64): Array[Byte] = {
+      val pre         = scheme.preDecode(s)
+      val cleanS      = pre.replaceAll("=+$", "")
+      val pad         = pre.length - cleanS.length
+      val computedPad = (4 - (cleanS.length % 4)) % 4
+      val r           = new ArrayBuilder.ofByte
+
+      if (scheme.strictPadding) {
+        if (pad > 2)
+          throw new java.lang.IllegalArgumentException(
+            "Invalid Base64 String: (excessive padding) " + s
+          )
+        if (s.length % 4 != 0)
+          throw new java.lang.IllegalArgumentException(
+            "Invalid Base64 String: (padding problem) " + s
+          )
+      }
+      if (computedPad == 3)
+        throw new java.lang.IllegalArgumentException("Invalid Base64 String: (string length) " + s)
+      try {
+        val s = (cleanS + "A" * computedPad)
+        for (x <- 0 until s.length - 1 by 4) {
+          val i = scheme.decodeTable(s.charAt(x).toInt) << 18 |
+            scheme.decodeTable(s.charAt(x + 1).toInt) << 12 |
+            scheme.decodeTable(s.charAt(x + 2).toInt) << 6 |
+            scheme.decodeTable(s.charAt(x + 3).toInt)
+          r += ((i >> 16).toByte)
+          r += ((i >> 8).toByte)
+          r += (i.toByte)
+        }
+      } catch {
+        case e: NoSuchElementException =>
+          throw new java.lang.IllegalArgumentException(
+            "Invalid Base64 String: (invalid character)" + e.getMessage + s
+          )
+      }
+      val res = r.result()
+      res.slice(0, res.length - computedPad)
+    }
+
+  }
+
+}

--- a/github4s/src/main/scala/github4s/interpreters/RepositoriesInterpreter.scala
+++ b/github4s/src/main/scala/github4s/interpreters/RepositoriesInterpreter.scala
@@ -21,7 +21,7 @@ import java.net.URLEncoder.encode
 import cats.Functor
 import cats.data.NonEmptyList
 import cats.syntax.functor._
-import com.github.marklister.base64.Base64._
+import github4s.internal.Base64._
 import github4s.Decoders._
 import github4s.Encoders._
 import github4s.GHResponse

--- a/github4s/src/test/scala/github4s/internal/Base64Spec.scala
+++ b/github4s/src/test/scala/github4s/internal/Base64Spec.scala
@@ -1,0 +1,110 @@
+package github4s.internal
+
+import Base64._
+import org.scalatest.funspec.AnyFunSpec
+
+class Base64Spec extends AnyFunSpec {
+
+  describe("encoding") {
+    it("encode1") {
+      assert("ABCDEFG".getBytes.toBase64 == "QUJDREVGRw==")
+    }
+
+    it("encode2") {
+      assert("homuho".getBytes.toBase64 == "aG9tdWhv")
+    }
+
+    it("encode3") {
+      assert("hogepiyofoobar".getBytes.toBase64 == "aG9nZXBpeW9mb29iYXI=")
+    }
+  }
+
+  describe("decoding") {
+
+    it("decode4") {
+      assert("aG9nZXBpeW9mb29iYXI=".toByteArray sameElements "hogepiyofoobar".getBytes)
+    }
+
+    it("decode5") {
+      assert("+/+/+/+/".toByteArray.sameElements("-_-_-_-_".toByteArray(base64Url)))
+    }
+
+  }
+
+  describe("RFC 4648 Test vectors") {
+
+    it("testBigInt") {
+      assert(BigInt("14fb9c03d97e", 16).toByteArray.toBase64 == "FPucA9l+")
+    }
+
+    it("test7") {
+      val testVectors = Seq(
+        ""       -> "",
+        "f"      -> "Zg==",
+        "fo"     -> "Zm8=",
+        "foo"    -> "Zm9v",
+        "foob"   -> "Zm9vYg==",
+        "fooba"  -> "Zm9vYmE=",
+        "foobar" -> "Zm9vYmFy"
+      )
+
+      for (t <- testVectors)
+        //test encoding
+        assert(t._1.getBytes.toBase64 == t._2)
+
+      for (t <- testVectors)
+        //test decoding
+        assert(t._2.toByteArray sameElements t._1.getBytes)
+    }
+
+    it("testunpaddedDecode") {
+      val testVectors = Seq(
+        ""       -> "",
+        "f"      -> "Zg==",
+        "fo"     -> "Zm8=",
+        "foo"    -> "Zm9v",
+        "foob"   -> "Zm9vYg==",
+        "fooba"  -> "Zm9vYmE=",
+        "foobar" -> "Zm9vYmFy"
+      )
+
+      for (t <- testVectors)
+        //test decoding
+        assert(
+          t._2.reverse.dropWhile(_ == '=').reverse.toByteArray(base64Url) sameElements t._1.getBytes
+        )
+    }
+
+    it("testBase64UrlPadding") {
+      val testVectors = Seq(
+        ""       -> "",
+        "f"      -> "Zg%3D%3D",
+        "fo"     -> "Zm8%3D",
+        "foo"    -> "Zm9v",
+        "foob"   -> "Zm9vYg%3D%3D",
+        "fooba"  -> "Zm9vYmE%3D",
+        "foobar" -> "Zm9vYmFy"
+      )
+
+      for (t <- testVectors)
+        //test encoding
+        assert(t._1.getBytes.toBase64(base64Url) == t._2)
+    }
+
+    it("testBase64UrlDecoding") {
+      val testVectors = Seq(
+        ""       -> "",
+        "f"      -> "Zg%3D%3D",
+        "fo"     -> "Zm8%3D",
+        "foo"    -> "Zm9v",
+        "foob"   -> "Zm9vYg%3D%3D",
+        "fooba"  -> "Zm9vYmE%3D",
+        "foobar" -> "Zm9vYmFy"
+      )
+
+      for (t <- testVectors)
+        //test encoding
+        assert(t._2.toByteArray(base64Url) sameElements t._1.getBytes)
+    }
+  }
+}

--- a/github4s/src/test/scala/github4s/unit/ReposSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/ReposSpec.scala
@@ -22,7 +22,7 @@ import github4s.Decoders._
 import github4s.Encoders._
 import github4s.domain._
 import github4s.http.HttpClient
-import com.github.marklister.base64.Base64._
+import github4s.internal.Base64._
 import github4s.interpreters.RepositoriesInterpreter
 import github4s.utils.BaseSpec
 import org.http4s

--- a/github4s/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/src/test/scala/github4s/utils/TestData.scala
@@ -18,7 +18,7 @@ package github4s.utils
 
 import java.util.UUID
 
-import com.github.marklister.base64.Base64._
+import github4s.internal.Base64._
 import github4s.domain._
 
 trait TestData {

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -15,7 +15,6 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val bm4                     = "0.3.1"
-      val base64: String          = "0.3.0"
       val cats: String            = "2.6.1"
       val circe: String           = "0.14.1"
       val expecty                 = "0.15.4"
@@ -69,20 +68,19 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val coreDeps = Seq(
       libraryDependencies ++= Seq(
-        "org.typelevel"         %% "cats-core"           % V.cats,
-        "io.circe"              %% "circe-core"          % V.circe,
-        "io.circe"              %% "circe-generic"       % V.circe,
-        "com.github.marklister" %% "base64"              % V.base64,
-        "org.http4s"            %% "http4s-client"       % V.http4s,
-        "org.http4s"            %% "http4s-circe"        % V.http4s,
-        "io.circe"              %% "circe-parser"        % V.circe                   % Test,
-        "com.eed3si9n.expecty"  %% "expecty"             % V.expecty                 % Test,
-        "org.scalatest"         %% "scalatest"           % V.scalatest               % Test,
-        "org.http4s"            %% "http4s-blaze-client" % V.http4s                  % Test,
-        "org.http4s"            %% "http4s-dsl"          % V.http4s                  % Test,
-        "org.http4s"            %% "http4s-server"       % V.http4s                  % Test,
-        "org.scalacheck"        %% "scalacheck"          % V.scalacheck              % Test,
-        "org.scalatestplus"     %% "scalacheck-1-15"     % V.scalacheckPlusScalatest % Test
+        "org.typelevel"        %% "cats-core"           % V.cats,
+        "io.circe"             %% "circe-core"          % V.circe,
+        "io.circe"             %% "circe-generic"       % V.circe,
+        "org.http4s"           %% "http4s-client"       % V.http4s,
+        "org.http4s"           %% "http4s-circe"        % V.http4s,
+        "io.circe"             %% "circe-parser"        % V.circe                   % Test,
+        "com.eed3si9n.expecty" %% "expecty"             % V.expecty                 % Test,
+        "org.scalatest"        %% "scalatest"           % V.scalatest               % Test,
+        "org.http4s"           %% "http4s-blaze-client" % V.http4s                  % Test,
+        "org.http4s"           %% "http4s-dsl"          % V.http4s                  % Test,
+        "org.http4s"           %% "http4s-server"       % V.http4s                  % Test,
+        "org.scalacheck"       %% "scalacheck"          % V.scalacheck              % Test,
+        "org.scalatestplus"    %% "scalacheck-1-15"     % V.scalacheckPlusScalatest % Test
       ),
       libraryDependencies ++= on(2, 12)(
         compilerPlugin("org.scalamacros" %% "paradise" % V.paradise cross CrossVersion.full)


### PR DESCRIPTION
They don't publish for scala3, and it was more expedient to vendor it in than PR upstream

It's published under the 2-clause BSD license, which should be compatible with our Apache-2 licensing. I've included attribution pointing to the original source