### PR TITLE
Ignores update branch integration test

### DIFF
--- a/github4s/src/test/scala/github4s/integration/PullRequestsSpec.scala
+++ b/github4s/src/test/scala/github4s/integration/PullRequestsSpec.scala
@@ -357,7 +357,7 @@ trait PullRequestsSpec extends BaseIntegrationSpec {
     removeReviewersResponse.statusCode shouldBe okStatusCode
   }
 
-  "PullRequests >> Update Branch" should "merge target branch's head into selected" taggedAs Integration in {
+  "PullRequests >> Update Branch" should "merge target branch's head into selected" taggedAs Integration ignore {
     val response = clientResource
       .use { client =>
         Github[IO](client, accessToken).pullRequests


### PR DESCRIPTION
We might need something like this https://github.com/47degrees/github4s/issues/395.

If the branch updated is related to an open PR, this incurs in recursion.