### PR TITLE
Fix #746 - Expand FileComparison to Rename/Patch cases

### DIFF
--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -246,13 +246,19 @@ object Decoders {
         )
       )
 
-  implicit val decoderFileComparisonModified: Decoder[FileComparison.FileComparisonModified] =
-    deriveDecoder[FileComparison.FileComparisonModified]
+  implicit val decoderFileComparisonNotRenamed: Decoder[FileComparison.FileComparisonNotRenamed] =
+    deriveDecoder[FileComparison.FileComparisonNotRenamed]
   implicit val decoderFileComparisonRenamed: Decoder[FileComparison.FileComparisonRenamed] =
     deriveDecoder[FileComparison.FileComparisonRenamed]
 
+  // Disambiguates between renamed and non-renamed cases based on status
   implicit val decoderFileComparison: Decoder[FileComparison] =
-    decoderFileComparisonModified.widen.or(decoderFileComparisonRenamed.widen)
+    Decoder.instance { c =>
+      c.downField("status").as[String].flatMap { status =>
+        if (status == "renamed") decoderFileComparisonRenamed(c)
+        else decoderFileComparisonNotRenamed(c)
+      }
+    }
 
   implicit val decoderCreatePullRequestData: Decoder[CreatePullRequestData] =
     deriveDecoder[CreatePullRequestData]

--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -246,13 +246,13 @@ object Decoders {
         )
       )
 
-  implicit val decoderFileComparisonPatch: Decoder[FileComparison.FileComparisonPatch] =
-    deriveDecoder[FileComparison.FileComparisonPatch]
-  implicit val decoderFileComparisonRename: Decoder[FileComparison.FileComparisonRename] =
-    deriveDecoder[FileComparison.FileComparisonRename]
+  implicit val decoderFileComparisonModified: Decoder[FileComparison.FileComparisonModified] =
+    deriveDecoder[FileComparison.FileComparisonModified]
+  implicit val decoderFileComparisonRenamed: Decoder[FileComparison.FileComparisonRenamed] =
+    deriveDecoder[FileComparison.FileComparisonRenamed]
 
   implicit val decoderFileComparison: Decoder[FileComparison] =
-    decoderFileComparisonPatch.widen.or(decoderFileComparisonRename.widen)
+    decoderFileComparisonModified.widen.or(decoderFileComparisonRenamed.widen)
 
   implicit val decoderCreatePullRequestData: Decoder[CreatePullRequestData] =
     deriveDecoder[CreatePullRequestData]

--- a/github4s/src/main/scala/github4s/Decoders.scala
+++ b/github4s/src/main/scala/github4s/Decoders.scala
@@ -246,7 +246,13 @@ object Decoders {
         )
       )
 
-  implicit val decoderFileComparison: Decoder[FileComparison] = deriveDecoder[FileComparison]
+  implicit val decoderFileComparisonPatch: Decoder[FileComparison.FileComparisonPatch] =
+    deriveDecoder[FileComparison.FileComparisonPatch]
+  implicit val decoderFileComparisonRename: Decoder[FileComparison.FileComparisonRename] =
+    deriveDecoder[FileComparison.FileComparisonRename]
+
+  implicit val decoderFileComparison: Decoder[FileComparison] =
+    decoderFileComparisonPatch.widen.or(decoderFileComparisonRename.widen)
 
   implicit val decoderCreatePullRequestData: Decoder[CreatePullRequestData] =
     deriveDecoder[CreatePullRequestData]

--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -247,13 +247,13 @@ object Encoders {
   implicit val encoderMilestone: Encoder[Milestone]               = deriveEncoder[Milestone]
   implicit val encodeBranchUpdateResponse: Encoder[BranchUpdateResponse] =
     deriveEncoder[BranchUpdateResponse]
-  implicit val encodeFileComparisonPatch: Encoder[FileComparison.FileComparisonPatch] =
-    deriveEncoder[FileComparison.FileComparisonPatch]
-  implicit val encodeFileComparisonRename: Encoder[FileComparison.FileComparisonRename] =
-    deriveEncoder[FileComparison.FileComparisonRename]
+  implicit val encodeFileComparisonModified: Encoder[FileComparison.FileComparisonModified] =
+    deriveEncoder[FileComparison.FileComparisonModified]
+  implicit val encodeFileComparisonRenamed: Encoder[FileComparison.FileComparisonRenamed] =
+    deriveEncoder[FileComparison.FileComparisonRenamed]
   implicit val encodeFileComparison: Encoder[FileComparison] = Encoder.instance {
-    case a: FileComparison.FileComparisonPatch  => encodeFileComparisonPatch(a)
-    case b: FileComparison.FileComparisonRename => encodeFileComparisonRename(b)
+    case a: FileComparison.FileComparisonModified => encodeFileComparisonModified(a)
+    case b: FileComparison.FileComparisonRenamed  => encodeFileComparisonRenamed(b)
   }
   implicit val encodeCommitComparisonResponse: Encoder[CommitComparisonResponse] =
     deriveEncoder[CommitComparisonResponse]

--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -247,13 +247,21 @@ object Encoders {
   implicit val encoderMilestone: Encoder[Milestone]               = deriveEncoder[Milestone]
   implicit val encodeBranchUpdateResponse: Encoder[BranchUpdateResponse] =
     deriveEncoder[BranchUpdateResponse]
-  implicit val encodeFileComparisonModified: Encoder[FileComparison.FileComparisonModified] =
-    deriveEncoder[FileComparison.FileComparisonModified]
+  implicit val encodeFileComparisonNotRenamed: Encoder[FileComparison.FileComparisonNotRenamed] =
+    deriveEncoder[FileComparison.FileComparisonNotRenamed]
+
+  // Ensures that the `status` field is populated when encoded as it is not part of the model.
   implicit val encodeFileComparisonRenamed: Encoder[FileComparison.FileComparisonRenamed] =
-    deriveEncoder[FileComparison.FileComparisonRenamed]
+    deriveEncoder[FileComparison.FileComparisonRenamed].mapJson { json =>
+      json.deepMerge(
+        Json.obj(
+          "status" -> Json.fromString("renamed")
+        )
+      )
+    }
   implicit val encodeFileComparison: Encoder[FileComparison] = Encoder.instance {
-    case a: FileComparison.FileComparisonModified => encodeFileComparisonModified(a)
-    case b: FileComparison.FileComparisonRenamed  => encodeFileComparisonRenamed(b)
+    case a: FileComparison.FileComparisonNotRenamed => encodeFileComparisonNotRenamed(a)
+    case b: FileComparison.FileComparisonRenamed    => encodeFileComparisonRenamed(b)
   }
   implicit val encodeCommitComparisonResponse: Encoder[CommitComparisonResponse] =
     deriveEncoder[CommitComparisonResponse]

--- a/github4s/src/main/scala/github4s/Encoders.scala
+++ b/github4s/src/main/scala/github4s/Encoders.scala
@@ -247,7 +247,14 @@ object Encoders {
   implicit val encoderMilestone: Encoder[Milestone]               = deriveEncoder[Milestone]
   implicit val encodeBranchUpdateResponse: Encoder[BranchUpdateResponse] =
     deriveEncoder[BranchUpdateResponse]
-  implicit val encodeFileComparison: Encoder[FileComparison] = deriveEncoder[FileComparison]
+  implicit val encodeFileComparisonPatch: Encoder[FileComparison.FileComparisonPatch] =
+    deriveEncoder[FileComparison.FileComparisonPatch]
+  implicit val encodeFileComparisonRename: Encoder[FileComparison.FileComparisonRename] =
+    deriveEncoder[FileComparison.FileComparisonRename]
+  implicit val encodeFileComparison: Encoder[FileComparison] = Encoder.instance {
+    case a: FileComparison.FileComparisonPatch  => encodeFileComparisonPatch(a)
+    case b: FileComparison.FileComparisonRename => encodeFileComparisonRename(b)
+  }
   implicit val encodeCommitComparisonResponse: Encoder[CommitComparisonResponse] =
     deriveEncoder[CommitComparisonResponse]
 }

--- a/github4s/src/main/scala/github4s/domain/Repository.scala
+++ b/github4s/src/main/scala/github4s/domain/Repository.scala
@@ -371,17 +371,34 @@ object RepoUrlKeys {
       files: Seq[FileComparison] = Seq.empty
   )
 
-  final case class FileComparison(
-      sha: String,
-      filename: String,
-      status: String,
-      additions: Int,
-      deletions: Int,
-      changes: Int,
-      blob_url: String,
-      raw_url: String,
-      contents_url: String,
-      patch: String
-  )
+  sealed trait FileComparison
+
+  object FileComparison {
+    final case class FileComparisonRename(
+        sha: String,
+        filename: String,
+        status: String,
+        additions: Int,
+        deletions: Int,
+        changes: Int,
+        blob_url: String,
+        raw_url: String,
+        contents_url: String,
+        previous_filename: String
+    ) extends FileComparison
+
+    final case class FileComparisonPatch(
+        sha: String,
+        filename: String,
+        status: String,
+        additions: Int,
+        deletions: Int,
+        changes: Int,
+        blob_url: String,
+        raw_url: String,
+        contents_url: String,
+        patch: String
+    ) extends FileComparison
+  }
 
 }

--- a/github4s/src/main/scala/github4s/domain/Repository.scala
+++ b/github4s/src/main/scala/github4s/domain/Repository.scala
@@ -373,9 +373,9 @@ object RepoUrlKeys {
 
   /**
    * A file comparison that contains information on the changes to a file.
-   * There are two subtypes: `FileComparisonModified` and `FileComparisonRenamed` that have different guarantees.
+   * There are two subtypes: `FileComparisonNotRenamed` and `FileComparisonRenamed` that have different guarantees.
    *
-   * * `FileComparisonModified` guarantees that the `patch` field exists, does not have a `previous_filename` field.
+   * * `FileComparisonNotRenamed` guarantees that the `patch` field exists, does not have a `previous_filename` field.
    * * `FileComparisonRenamed` guarantees that the `previous_filename` field exists and sometimes contains a `patch` field.
    *
    * To get values from these fields, there are helper methods `getPatch` and `getPreviousFilename`, though
@@ -395,7 +395,7 @@ object RepoUrlKeys {
     /**
      * Gets the contents of the `patch` field if it exists, in the case that the file was modified.
      * To guarantee that the `patch` field is available, match this `FileComparison` value as a
-     * `FileComparison.FileComparisonModified` type which always has this field.
+     * `FileComparison.FileComparisonNotRenamed` type which always has this field.
      */
     def getPatch: Option[String]
 
@@ -418,7 +418,6 @@ object RepoUrlKeys {
     final case class FileComparisonRenamed(
         sha: String,
         filename: String,
-        status: String,
         additions: Int,
         deletions: Int,
         changes: Int,
@@ -428,12 +427,13 @@ object RepoUrlKeys {
         patch: Option[String],
         previous_filename: String
     ) extends FileComparison {
+      val status: String                      = "renamed"
       def getPatch: Option[String]            = patch
       def getPreviousFilename: Option[String] = Some(previous_filename)
     }
 
-    /** Represents a file comparison where a file was modified in-place with no rename. */
-    final case class FileComparisonModified(
+    /** Represents a file comparison where a file was not renamed. */
+    final case class FileComparisonNotRenamed(
         sha: String,
         filename: String,
         status: String,


### PR DESCRIPTION
Fixes #746 

Took a slightly different approach than the one suggested. Because it seems like there are two distinct cases, I felt the user of the library should not have to know that these fields are mutually exclusive, and it should be instead clear from the models. If the `patch` field exists, it should be a `String` and not `Option[String]` since it sounds like that means there will also be no `previous_filename` field (and vice versa).

I've added two additional cases for `FileComparison` as `FileComparisonRename` and `FileComparisonPatch` that contain these two exclusive cases as separate models. It involves a little copy/paste but nothing egregious and I think this is better for end-users than the alternative anyway.

Either way, this is a breaking model change and should be noted when released.

EDIT: based on the below discussion, it seems the fields are not mutually exclusive but in the case of a rename there will always be `previous_filename` but not always a `patch`. I've modified the cases to match, and I've added methods to get these from the common supertype if they exist as `Option[String]`.