### PR TITLE
Add new endpoint - List public organization events

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ If you wish to add your library here please consider a PR to include it in the l
 
 Github4s is designed and developed by 47 Degrees
 
-Copyright (C) 2016-2020 47 Degrees. <http://47deg.com>
+Copyright (C) 2016-2022 47 Degrees. <http://47deg.com>

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,4 +28,4 @@ If you wish to add your library here please consider a PR to include it in the l
 
 Github4s is designed and developed by 47 Degrees
 
-Copyright (C) 2016-2020 47 Degrees. <http://47deg.com>
+Copyright (C) 2016-2022 47 Degrees. <http://47deg.com>

--- a/github4s/shared/src/main/scala/github4s/Decoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Decoders.scala
@@ -246,6 +246,25 @@ object Decoders {
         )
       )
 
+  implicit val decodePublicOrganizationEvent: Decoder[PublicOrganizationEvent] =
+    Decoder.instance(c =>
+      for {
+        id             <- c.downField("id").as[Long]
+        event_type     <- c.downField("type").as[String]
+        actor_login    <- c.downField("actor").downField("login").as[String]
+        repo_full_name <- c.downField("repo").downField("full_name").as[String]
+        public         <- c.downField("public").as[Boolean]
+        created_at     <- c.downField("created_at").as[String]
+      } yield PublicOrganizationEvent(
+        id,
+        event_type,
+        actor_login,
+        repo_full_name,
+        public,
+        created_at
+      )
+    )
+
   implicit val decoderFileComparisonNotRenamed: Decoder[FileComparison.FileComparisonNotRenamed] =
     deriveDecoder[FileComparison.FileComparisonNotRenamed]
   implicit val decoderFileComparisonRenamed: Decoder[FileComparison.FileComparisonRenamed] =

--- a/github4s/shared/src/main/scala/github4s/Encoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Encoders.scala
@@ -238,6 +238,23 @@ object Encoders {
         case None => repo
       }
     }
+
+  implicit val encoderPublicOrganizationEvents: Encoder[PublicOrganizationEvent] =
+    Encoder.instance { e =>
+      Json.obj(
+        "id"         -> e.id.asJson,
+        "type"       -> e.`type`.asJson,
+        "public"     -> e.public.asJson,
+        "created_at" -> e.created_at.asJson,
+        "actor" -> Json.obj(
+          "login" -> e.actor_login.asJson
+        ),
+        "repo" -> Json.obj(
+          "full_name" -> e.repo_full_name.asJson
+        )
+      )
+    }
+
   implicit val encoderIssue: Encoder[Issue]                       = deriveEncoder[Issue]
   implicit val encoderIssuePullRequest: Encoder[IssuePullRequest] = deriveEncoder[IssuePullRequest]
   implicit val encoderGistFile: Encoder[GistFile]                 = deriveEncoder[GistFile]

--- a/github4s/shared/src/main/scala/github4s/algebras/Activities.scala
+++ b/github4s/shared/src/main/scala/github4s/algebras/Activities.scala
@@ -76,4 +76,18 @@ trait Activities[F[_]] {
       headers: Map[String, String] = Map()
   ): F[GHResponse[List[StarredRepository]]]
 
+  /**
+   * List the events of a particular public organization
+   *
+   * @param org Organization for which we wish to retrieve the events
+   * @param pagination Limit and Offset for pagination
+   * @param headers Optional user headers to include in the request
+   * @return GHResponse with the list of events for this public organization
+   */
+  def listPublicOrganizationEvents(
+      org: String,
+      pagination: Option[Pagination] = None,
+      headers: Map[String, String] = Map()
+  ): F[GHResponse[List[PublicOrganizationEvent]]]
+
 }

--- a/github4s/shared/src/main/scala/github4s/domain/Activity.scala
+++ b/github4s/shared/src/main/scala/github4s/domain/Activity.scala
@@ -39,3 +39,12 @@ final case class StarredRepository(
     repo: Repository,
     starred_at: Option[String] = None
 )
+
+final case class PublicOrganizationEvent(
+    id: Long,
+    `type`: String,
+    actor_login: String,
+    repo_full_name: String,
+    public: Boolean,
+    created_at: String
+)

--- a/github4s/shared/src/main/scala/github4s/interpreters/ActivitiesInterpreter.scala
+++ b/github4s/shared/src/main/scala/github4s/interpreters/ActivitiesInterpreter.scala
@@ -27,6 +27,8 @@ class ActivitiesInterpreter[F[_]](implicit client: HttpClient[F]) extends Activi
 
   private val timelineHeader = ("Accept" -> "application/vnd.github.v3.star+json")
 
+  private val eventsRecommendedHeader = ("Accept" -> "application/vnd.github.v3+json")
+
   override def setThreadSub(
       id: Long,
       subscribed: Boolean,
@@ -69,4 +71,17 @@ class ActivitiesInterpreter[F[_]](implicit client: HttpClient[F]) extends Activi
       ).collect { case (key, Some(value)) => key -> value },
       pagination = pagination
     )
+
+  override def listPublicOrganizationEvents(
+      org: String,
+      pagination: Option[Pagination],
+      headers: Map[String, String]
+  ): F[GHResponse[List[PublicOrganizationEvent]]] =
+    client.get[List[PublicOrganizationEvent]](
+      method = s"orgs/$org/events",
+      headers + eventsRecommendedHeader,
+      Map.empty,
+      pagination = pagination
+    )
+
 }

--- a/github4s/shared/src/test/scala/github4s/unit/ActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/ActivitiesSpec.scala
@@ -70,4 +70,18 @@ class ActivitiesSpec extends BaseSpec {
       .shouldNotFail
   }
 
+  "Activity.listPublicOrganizationEvents" should "call to httpClient.get with the right parameters" in {
+
+    implicit val httpClientMock: HttpClient[IO] = httpClientMockGet[List[PublicOrganizationEvent]](
+      url = s"orgs/$validOrganizationName/events",
+      response = IO.pure(List(publicOrganizationEvent))
+    )
+
+    val activities = new ActivitiesInterpreter[IO]
+
+    activities
+      .listPublicOrganizationEvents(validUsername, None, headerUserAgent)
+      .shouldNotFail
+  }
+
 }

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -439,6 +439,15 @@ trait TestData {
   val stargazer         = Stargazer(user)
   val starredRepository = StarredRepository(repo)
 
+  val publicOrganizationEvent = PublicOrganizationEvent(
+    id = 21492285567L,
+    `type` = "PushEvent",
+    actor_login = "47erbot",
+    repo_full_name = "47degrees/github4s",
+    public = true,
+    created_at = "2022-04-27T05:29:31Z"
+  )
+
   val pullRequestReview = PullRequestReview(
     id = validPullRequestReviewNumber,
     user = Some(user),

--- a/microsite/docs/activity.md
+++ b/microsite/docs/activity.md
@@ -14,6 +14,7 @@ with Github4s, you can interact with:
 - [Starring](#starring)
   - [List stargazers](#list-stargazers)
   - [List starred repositories](#list-starred-repositories)
+  - [List public organization events](#list-public-organization-events)
 
 The following examples assume the following code:
 
@@ -104,6 +105,29 @@ listStarredRepositories.flatMap(_.result match {
 The `result` on the right is the corresponding [List[StarredRepository]][activity-scala].
 
 See [the API doc](https://developer.github.com/v3/activity/starring/#list-repositories-being-starred)
+for full reference.
+
+### List public organization events
+
+You can list the events of a particular public organization with `listPublicOrganizationEvents`; it takes
+as arguments:
+
+- `org`: name of the organization for which we want to retrieve the events.
+- `pagination`: Limit and Offset for pagination, optional.
+
+To list the events for org `47degrees`:
+
+```scala mdoc:compile-only
+val listPublicOrganizationEvents = gh.activities.listPublicOrganizationEvents("47degrees")
+listPublicOrganizationEvents.flatMap(_.result match {
+  case Left(e)  => IO.println(s"Something went wrong: ${e.getMessage}")
+  case Right(r) => IO.println(r)
+})
+```
+
+The `result` on the right is the corresponding [List[PublicOrganizationEvent]][activity-scala].
+
+See [the API doc](https://docs.github.com/en/rest/activity/events#list-public-organization-events)
 for full reference.
 
 As you can see, a few features of the activity endpoint are missing.


### PR DESCRIPTION
Implemented endpoint for https://docs.github.com/en/rest/activity/events#list-public-organization-events

Went with a "minimalist" approach mapping only core fields, in a future PR we can improve mapping the payload (per-event-type) fields.
https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types

Ready for review.
