### PR TITLE
Bumps http4s and circe

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -7,6 +7,5 @@
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 # effectively adds GC to Perm space
--XX:+UseConcMarkSweepGC
 -XX:+CMSClassUnloadingEnabled
 # must be enabled for CMSClassUnloadingEnabled to work

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -16,9 +16,9 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val bm4                     = "0.3.1"
       val cats: String            = "2.7.0"
-      val circe: String           = "0.14.1"
+      val circe: String           = "0.14.2"
       val expecty                 = "0.15.4"
-      val http4s: String          = "0.23.11"
+      val http4s: String          = "0.23.12"
       val paradise: String        = "2.1.1"
       val scalacheck              = "1.16.0"
       val scalacheckShapeless     = "1.3.0"


### PR DESCRIPTION
It bumps http4s and circe. circe changed the internal error but in my opinion, we shouldn't be checking that behavior in the tests.

It also removes a deprecated setting in the JMV.