### PR TITLE
Fix GithubPublicEvent schema

### DIFF
--- a/github4s/shared/src/main/scala/github4s/Decoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Decoders.scala
@@ -252,17 +252,17 @@ object Decoders {
   implicit val decodePublicGitHubEvent: Decoder[PublicGitHubEvent] =
     Decoder.instance(c =>
       for {
-        id             <- c.downField("id").as[Long]
-        event_type     <- c.downField("type").as[String]
-        actor_login    <- c.downField("actor").downField("login").as[String]
-        repo_full_name <- c.downField("repo").downField("full_name").as[String]
-        public         <- c.downField("public").as[Boolean]
-        created_at     <- c.downField("created_at").as[String]
+        id          <- c.downField("id").as[Long]
+        event_type  <- c.downField("type").as[String]
+        actor_login <- c.downField("actor").downField("login").as[String]
+        repo_name   <- c.downField("repo").downField("name").as[String]
+        public      <- c.downField("public").as[Boolean]
+        created_at  <- c.downField("created_at").as[String]
       } yield PublicGitHubEvent(
         id,
         event_type,
         actor_login,
-        repo_full_name,
+        repo_name,
         public,
         created_at
       )

--- a/github4s/shared/src/main/scala/github4s/Encoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Encoders.scala
@@ -252,7 +252,7 @@ object Encoders {
           "login" -> e.actor_login.asJson
         ),
         "repo" -> Json.obj(
-          "full_name" -> e.repo_full_name.asJson
+          "name" -> e.repo_name.asJson
         )
       )
     }

--- a/github4s/shared/src/main/scala/github4s/domain/Activity.scala
+++ b/github4s/shared/src/main/scala/github4s/domain/Activity.scala
@@ -44,7 +44,7 @@ final case class PublicGitHubEvent(
     id: Long,
     `type`: String,
     actor_login: String,
-    repo_full_name: String,
+    repo_name: String,
     public: Boolean,
     created_at: String
 )

--- a/github4s/shared/src/test/scala/github4s/integration/ActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/ActivitiesSpec.scala
@@ -158,7 +158,7 @@ trait ActivitiesSpec extends BaseIntegrationSpec {
         r.nonEmpty shouldBe true
         forAll(r)(s => s.public shouldBe true)
         forAll(r)(s => s.actor_login.nonEmpty shouldBe true)
-        forAll(r)(s => s.repo_full_name.nonEmpty shouldBe true)
+        forAll(r)(s => s.repo_name.nonEmpty shouldBe true)
       }
     )
     response.statusCode shouldBe okStatusCode
@@ -190,7 +190,7 @@ trait ActivitiesSpec extends BaseIntegrationSpec {
         r.nonEmpty shouldBe true
         forAll(r)(s => s.public shouldBe true)
         forAll(r)(s => s.actor_login.nonEmpty shouldBe true)
-        forAll(r)(s => s.repo_full_name.nonEmpty shouldBe true)
+        forAll(r)(s => s.repo_name.nonEmpty shouldBe true)
       }
     )
     response.statusCode shouldBe okStatusCode

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -443,7 +443,7 @@ trait TestData {
     id = 21492285567L,
     `type` = "PushEvent",
     actor_login = "47erbot",
-    repo_full_name = "47degrees/github4s",
+    repo_name = "47degrees/github4s",
     public = true,
     created_at = "2022-04-27T05:29:31Z"
   )


### PR DESCRIPTION
After https://github.com/47degrees/github4s/pull/817 the tests for the following operations are failing:  

- List public organization events
- List repository events

That's because the expected schema in the code doesn't match with the JSON returned by the GitHub API. The field `repo.full_name` doesn't exist; instead, we can get the `repo.name` field. 

For further reference: https://docs.github.com/en/rest/activity/events#list-public-repository-events, https://docs.github.com/en/rest/activity/events#list-public-repository-events
